### PR TITLE
Load SAP Theme (from metadata) and also initialize theme in UI5

### DIFF
--- a/head.html
+++ b/head.html
@@ -3,4 +3,3 @@
 <script src="/scripts/scripts.js" type="module"></script>
 <script src="/libs/bundle.esm.m.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
-<link rel="stylesheet" type="text/css" href="/themes/sap_glow/css_variables.css">

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,17 +1,17 @@
 import {
-  sampleRUM,
   buildBlock,
-  loadHeader,
-  loadFooter,
+  decorateBlocks,
   decorateButtons,
   decorateIcons,
   decorateSections,
-  decorateBlocks,
   decorateTemplateAndTheme,
-  waitForLCP,
   getMetadata,
   loadBlocks,
   loadCSS,
+  loadFooter,
+  loadHeader,
+  sampleRUM,
+  waitForLCP,
 } from './aem.js';
 
 const LCP_BLOCKS = ['hero']; // add your LCP blocks to the list
@@ -108,6 +108,32 @@ async function decorateTemplates(main) {
   }
 }
 
+async function loadSAPTheme() {
+  try {
+    const sapTheme = getMetadata('saptheme', document) || 'sap_glow';
+    if (sapTheme) {
+      const head = document.querySelector('head');
+      // <link rel="stylesheet" type="text/css" href="/themes/sap_glow/css_variables.css">
+      const designTokenLink = document.createElement('link');
+      designTokenLink.setAttribute('rel', 'stylesheet');
+      designTokenLink.setAttribute('type', 'text/css');
+      const themeLink = `/themes/${sapTheme}/css_variables.css`;
+      designTokenLink.setAttribute('href', themeLink);
+      head.append(designTokenLink);
+
+      // <script data-ui5-config type="application/json">{"theme": "sap_glow"}</script>
+      const ui5ThemeScript = document.createElement('script');
+      ui5ThemeScript.setAttribute('data-ui5-config', '');
+      ui5ThemeScript.setAttribute('type', 'application/json');
+      ui5ThemeScript.textContent = `{"theme": "${sapTheme}"}`;
+      head.append(ui5ThemeScript);
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('SAP-Theme loading failed', e);
+  }
+}
+
 /**
  * Loads everything needed to get to LCP.
  * @param {Element} doc The container element
@@ -119,6 +145,7 @@ async function loadEager(doc) {
   if (main) {
     decorateMain(main);
     await decorateTemplates(main);
+    loadSAPTheme();
     document.body.classList.add('appear');
     await waitForLCP(LCP_BLOCKS);
   }


### PR DESCRIPTION
fix: sap-theme is loaded. Currently, the data is not loaded from metadata.xlsx

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #13

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.page/blog/2023/11/supply-chain-issues-keeping-ceos-up-at-night
- After: https://13-load-theme-init-ui5-comp--hlx-test--urfuwo.hlx.page/blog/2023/11/supply-chain-issues-keeping-ceos-up-at-night
