### PR TITLE
Global styling iteration 1

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -19,7 +19,8 @@
   display: block;
 }
 
-@media (width >= 900px) {
+/* Desktop view (--udexGridMMinWidth) */
+@media (width >= 980px) {
   .columns > div {
     align-items: center;
     flex-direction: unset;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1,3 +1,7 @@
+header {
+  height: 64px;
+}
+
 /* header and nav layout */
 header .nav-wrapper {
   display: flex;
@@ -5,7 +9,7 @@ header .nav-wrapper {
   justify-content: space-between;
   padding: 0 72px;
   position: relative;
-  background-color: var(--sap-shell-background);
+  background-color: var(--sapShell_Background);
   width: auto;
 }
 
@@ -38,24 +42,30 @@ header nav .text {
   white-space: nowrap;
 }
 
+/* Table view (--udexGridSMinWidth) */
 @media (width >= 640px) {
   header nav {
     padding: 0 48px;
   }
 }
 
+/* Desktop view (--udexGridMMinWidth) */
 @media (width >= 980px) {
   header nav {
     padding: 0 72px;
   }
 }
 
+/* XL Desktop view (--udexGridXLMinWidth) */
 @media (width >= 1600px) {
   header nav {
     padding: 0 246px;
   }
 }
 
+/* #todo: it appears this media query can be collapsed with the previous one */
+
+/* XL Desktop view (--udexGridXLMinWidth) */
 @media (width >= 1600px) {
   header nav {
     gap: 0 2em;
@@ -144,7 +154,8 @@ header nav .nav-sections ul > li > ul > li {
   font-weight: 500;
 }
 
-@media (width >= 900px) {
+/* Desktop view (--udexGridMMinWidth) */
+@media (width >= 980px) {
   header nav .nav-sections {
     display: inline-flex;
     visibility: visible;
@@ -203,7 +214,8 @@ header nav .nav-explore {
   display: none;
 }
 
-@media (width >= 900px) {
+/* Desktop view (--udexGridMMinWidth) */
+@media (width >= 980px) {
   header nav .nav-explore {
     display: inline;
     align-self: flex-end;
@@ -220,7 +232,8 @@ header nav .nav-tools {
   display: none;
 }
 
-@media (width >= 900px) {
+/* Desktop view (--udexGridMMinWidth) */
+@media (width >= 980px) {
   header nav .nav-tools {
     display: inline-flex;
     align-items: flex-end;
@@ -343,7 +356,8 @@ header nav[aria-expanded='true'] .nav-hamburger-icon::after {
   transform: rotate(-45deg);
 }
 
-@media (width >= 900px) {
+/* Desktop view (--udexGridMMinWidth) */
+@media (width >= 980px) {
   header nav .nav-hamburger {
     display: none;
     visibility: hidden;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1,7 +1,3 @@
-header {
-  height: 64px;
-}
-
 /* header and nav layout */
 header .nav-wrapper {
   display: flex;
@@ -9,7 +5,7 @@ header .nav-wrapper {
   justify-content: space-between;
   padding: 0 72px;
   position: relative;
-  background-color: var(--sapShell_Background);
+  background-color: var(--sap-shell-background);
   width: auto;
 }
 
@@ -42,30 +38,24 @@ header nav .text {
   white-space: nowrap;
 }
 
-/* Table view (--udexGridSMinWidth) */
 @media (width >= 640px) {
   header nav {
     padding: 0 48px;
   }
 }
 
-/* Desktop view (--udexGridMMinWidth) */
 @media (width >= 980px) {
   header nav {
     padding: 0 72px;
   }
 }
 
-/* XL Desktop view (--udexGridXLMinWidth) */
 @media (width >= 1600px) {
   header nav {
     padding: 0 246px;
   }
 }
 
-/* #todo: it appears this media query can be collapsed with the previous one */
-
-/* XL Desktop view (--udexGridXLMinWidth) */
 @media (width >= 1600px) {
   header nav {
     gap: 0 2em;
@@ -154,8 +144,7 @@ header nav .nav-sections ul > li > ul > li {
   font-weight: 500;
 }
 
-/* Desktop view (--udexGridMMinWidth) */
-@media (width >= 980px) {
+@media (width >= 900px) {
   header nav .nav-sections {
     display: inline-flex;
     visibility: visible;
@@ -214,8 +203,7 @@ header nav .nav-explore {
   display: none;
 }
 
-/* Desktop view (--udexGridMMinWidth) */
-@media (width >= 980px) {
+@media (width >= 900px) {
   header nav .nav-explore {
     display: inline;
     align-self: flex-end;
@@ -232,8 +220,7 @@ header nav .nav-tools {
   display: none;
 }
 
-/* Desktop view (--udexGridMMinWidth) */
-@media (width >= 980px) {
+@media (width >= 900px) {
   header nav .nav-tools {
     display: inline-flex;
     align-items: flex-end;
@@ -356,8 +343,7 @@ header nav[aria-expanded='true'] .nav-hamburger-icon::after {
   transform: rotate(-45deg);
 }
 
-/* Desktop view (--udexGridMMinWidth) */
-@media (width >= 980px) {
+@media (width >= 900px) {
   header nav .nav-hamburger {
     display: none;
     visibility: hidden;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -1,9 +1,11 @@
 main .hero-container > div {
   max-width: unset;
 }
-  
+
 main .hero-container {
-  padding: 0;
+  /* do not change padding-bottom */
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .hero {
@@ -12,10 +14,13 @@ main .hero-container {
 }
 
 .hero h1 {
+  font-family: var(--udexTypographyHeadingMediumLFontFamily);
+  font-size: var(--udexTypographyHeadingMediumLFontSize);
+  font-weight: var(--udexTypographyHeadingMediumLFontWeight);
+  line-height: var(--udexTypographyHeadingMediumLLineHeight);
   max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
-  color: white;
 }
 
 .hero picture {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -8,6 +8,11 @@ main .hero-container {
   padding-right: 0;
 }
 
+main div.hero-wrapper {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 .hero {
   position: relative;
   min-height: 300px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -104,6 +104,7 @@ a:any-link {
 }
 
 a:hover {
+  color: var(--udexColorBlue9);
   cursor: pointer;
   text-decoration: underline;
 }
@@ -165,14 +166,14 @@ main .section {
   padding-bottom: 56px;
 }
 
-main .section > div:not(.hero-wrapper) {
+main .section > div {
   margin-left: 18px; /* missing design, assumption */
   margin-right: 18px; /* missing design, assumption */
 }
 
 /* Tablet view (--udexGridSMinWidth) */
 @media (width >= 640px) {
-  main .section > div:not(.hero-wrapper) {
+  main .section > div {
     margin-left: 36px; /* missing design, assumption */
     margin-right: 36px; /* missing design, assumption */
   }
@@ -180,7 +181,7 @@ main .section > div:not(.hero-wrapper) {
 
 /* Desktop view (--udexGridMMinWidth) */
 @media (width >= 980px) {
-  main .section > div:not(.hero-wrapper) {
+  main .section > div {
     margin-left: 72px;
     margin-right: 72px;
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,75 +1,26 @@
 /*
  * SAP root styles using theme design tokens (see themes/sap_glow/css_variables.css)
+ * Currently implements three breakpoints:
+ * - min:0px (mobile first, default)
+ * - min:640px (--udexGridSMinWidth)
+ * - min:980px (--udexGridMMinWidth)
+ * - min:1600px (--udexGridXLMinWidth)
+ * Heading/Medium: per-element
+ * Heading/Regular: default
  */
 :root {
-  /* colors */
-  --link-color: var(--sapLinkColor);
-  --link-hover-color: var(--sapLink_Hover_Color);
-  --background-color: white;
-  --light-color: #eee;
-  --dark-color: #ccc;
-  --text-color: black;
-
-  /* fonts */
-  --body-font-family: var(--udexTypographyBodyMFontFamily);
-  --heading-font-family: var(--udexTypographyHeadingRegularMFontFamily);
-  --fixed-font-family: 'Roboto Mono', menlo, consolas, 'Liberation Mono',
-    monospace;
-
-  /* body sizes */
-  --body-font-size-m: var(--udexTypographyBodyMFontSize);
-  --body-font-size-s: var(--udexTypographyBodySFontSize);
-  --body-font-size-xs: var(--udexTypographyBodyXSFontSize);
-
-  /* body line height */
-  --body-line-height-m: var(--udexTypographyBodyMLineHeight);
-
-  /* heading sizes */
-  --heading-font-size-xxl: 48px;
-  --heading-font-size-xl: 40px;
-  --heading-font-size-l: 32px;
-  --heading-font-size-m: 24px;
-  --heading-font-size-s: 20px;
-  --heading-font-size-xs: 18px;
-
-  /* nav height */
-  --nav-height: 64px;
-
-  /* breakpoints */
-  --sap-breakpoint-XL-min: 1600px;
-  --sap-breakpoint-L-max: 1599px;
-  --sap-breakpoint-L-min: 1280px;
-  --sap-breakpoint-M-max: 1279px;
-  --sap-breakpoint-M-min: 980px;
-  --sap-breakpoint-S-max: 979px;
-  --sap-breakpoint-S-min: 640px;
-  --sap-breakpoint-XS-max: 639px;
-  --sap-breakpoint-XS-min: 360px;
-}
-
-@font-face {
-  font-family: roboto-fallback;
-  size-adjust: 100.06%;
-  ascent-override: 95%;
-  src: local('Arial');
-}
-
-@media (width >= 900px) {
-  :root {
-    --heading-font-size-xxl: 60px;
-    --heading-font-size-xl: 48px;
-    --heading-font-size-l: 36px;
-    --heading-font-size-m: 30px;
-    --heading-font-size-s: 24px;
-    --heading-font-size-xs: 22px;
-  }
+  /* default colors */
+  --background-color: var(--udexColorNeutralWhite);
+  --text-color: var(--sapShell_TextColor);
 }
 
 body {
-  font-size: var(--body-font-size-m);
+  font-family: var(--udexTypographyBodySFontFamily);
+  font-size: var(--udexTypographyBodySFontSize);
+  font-weight: var(--udexTypographyBodySFontWeight);
+  line-height: var(--udexTypographyBodySLineHeight);
   margin: 0;
-  font-family: var(--body-font-family);
-  line-height: var(--body-line-height-m);
+  padding-left: 0;
   color: var(--text-color);
   background-color: var(--background-color);
   display: none;
@@ -79,48 +30,46 @@ body.appear {
   display: block;
 }
 
-header {
-  height: var(--nav-height);
-}
-
-h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  font-family: var(--heading-font-family-m);
-  font-weight: 600;
-  line-height: 1.25;
-  margin-top: 1em;
-  margin-bottom: 0.5em;
-  scroll-margin: calc(var(--nav-height) + 1em);
+  margin-top: 2rem; /* 32px */
+  margin-bottom: 0.5rem; /* 8px */
 }
 
 h1 {
-  font-size: var(--heading-font-size-xxl);
+  font-family: var(--udexTypographyHeadingRegularMFontFamily);
+  font-size: var(--udexTypographyHeadingRegularMFontSize);
+  font-weight: var(--udexTypographyHeadingRegularMFontWeight);
+  line-height: var(--udexTypographyHeadingRegularMLineHeight);
 }
 
 h2 {
-  font-size: var(--heading-font-size-xl);
+  font-family: var(--udexTypographyHeadingRegularSFontFamily);
+  font-size: var(--udexTypographyHeadingRegularSFontSize);
+  font-weight: var(--udexTypographyHeadingRegularSFontWeight);
+  line-height: var(--udexTypographyHeadingRegularSLineHeight);
 }
 
+/* missing design, assumption */
 h3 {
-  font-size: var(--heading-font-size-l);
+  font-family: var(--udexTypographyHeadingRegularXSFontFamily);
+  font-size: var(--udexTypographyHeadingRegularXSFontSize);
+  font-weight: var(--udexTypographyHeadingRegularXSFontWeight);
+  line-height: var(--udexTypographyHeadingRegularXSLineHeight);
 }
 
-h4 {
-  font-size: var(--heading-font-size-m);
+/* missing styles, assumption */
+h4, h5, h6 {
+  font-family: var(--udexTypographyHeadingRegularXXSFontFamily);
+  font-size: var(--udexTypographyHeadingRegularXXSFontSize);
+  font-weight: var(--udexTypographyHeadingRegularXXSFontWeight);
+  line-height: var(--udexTypographyHeadingRegularXXSLineHeight);
 }
 
-h5 {
-  font-size: var(--heading-font-size-s);
-}
-
-h6 {
-  font-size: var(--heading-font-size-xs);
-}
-
+/* missing styles, assumption */
 p,
 dl,
 ol,
@@ -131,43 +80,37 @@ blockquote {
   margin-bottom: 1em;
 }
 
-code,
-pre {
-  font-family: var(--fixed-font-family);
-  font-size: var(--body-font-size-s);
-}
-
+/* missing styles, assumption */
 code {
   padding: 0.125em;
 }
 
+/* missing styles, assumption */
 pre {
   overflow: scroll;
 }
 
+/* missing styles, assumption */
 main pre {
-  background-color: var(--light-color);
   padding: 1em;
   border-radius: 0.25em;
   overflow-x: auto;
   white-space: pre;
 }
 
-/* links */
 a:any-link {
-  color: var(--link-color);
-  text-decoration: none;
+  color: var(--udexColorBlue7);
+  text-decoration: underline;
 }
 
 a:hover {
   cursor: pointer;
-  text-decoration: none;
+  text-decoration: underline;
 }
 
-/* buttons */
+/* missing styles, assumption */
 a.button:any-link,
 button {
-  font-family: var(--body-font-family);
   display: inline-block;
   box-sizing: border-box;
   text-decoration: none;
@@ -185,6 +128,7 @@ button {
   border-radius: 30px;
 }
 
+/* missing styles, assumption */
 a.button:hover,
 a.button:focus,
 button:hover,
@@ -193,17 +137,10 @@ button:focus {
   cursor: pointer;
 }
 
+/* missing styles, assumption */
 button:disabled,
 button:disabled:hover {
-  background-color: var(--light-color);
   cursor: unset;
-}
-
-a.button.secondary,
-button.secondary {
-  background-color: unset;
-  border: 2px solid currentcolor;
-  color: var(--text-color);
 }
 
 main img {
@@ -223,26 +160,28 @@ main img {
   width: 100%;
 }
 
-/* sections */
+/* sections: 56px spacing at the bottom */
 main .section {
-  padding: 64px 16px;
+  padding-bottom: 56px;
 }
 
-@media (width >= 600px) {
-  main .section {
-    padding: 64px 32px;
+main .section > div:not(.hero-wrapper) {
+  margin-left: 18px; /* missing design, assumption */
+  margin-right: 18px; /* missing design, assumption */
+}
+
+/* Tablet view (--udexGridSMinWidth) */
+@media (width >= 640px) {
+  main .section > div:not(.hero-wrapper) {
+    margin-left: 36px; /* missing design, assumption */
+    margin-right: 36px; /* missing design, assumption */
   }
 }
 
-@media (width >= 900px) {
-  .section > div {
-    max-width: 1200px;
-    margin: auto;
+/* Desktop view (--udexGridMMinWidth) */
+@media (width >= 980px) {
+  main .section > div:not(.hero-wrapper) {
+    margin-left: 72px;
+    margin-right: 72px;
   }
-}
-
-/* section metadata */
-main .section.light,
-main .section.highlight {
-  background-color: var(--light-color);
 }

--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -15,7 +15,7 @@
 
 /* Blog-CTA-Banner */
 .blog .blog-cta-banner {
-    background-color: var(--sapProgress_Value_InformationBackground);
+    background-color: var(--sapBrandColor);
     margin: 3rem auto;
     padding: 2rem;
 }

--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -1,16 +1,16 @@
 /**
- * Blog mobile first
+ * Blog, mobile first
  */
 
 /* Blog paragraph spacing */
 .blog p, .feature-article p {
-    margin-top: 18px;
-    margin-bottom: 18px;
+    margin-top: 18px; /* no design, assumption */
+    margin-bottom: 18px; /* no design, assumption */
 }
 
 /* Highlight first paragraph of blog pages using increased font size */
 .blog p.blog--highlight, .feature-article p.blog--highlight {
-    font-size: var(--udexTypographyBodyXLFontSize);
+    font-size: var(--udexTypographyBodyLFontSize); /* no design, assumption */
 }
 
 /* Blog-CTA-Banner */
@@ -51,24 +51,19 @@
     text-decoration: none;
 }
 
-/* Desktop view */
-@media (min-width: 900px) {
-    .blog div.section > div:not(.hero-wrapper) {
-        margin-left: auto;
-        margin-right: auto;
-        padding-left: 180px;
-        padding-right: 180px;
-        width: 780px;
-        max-width: 780px;
+/* Desktop view (--udexGridMMinWidth) */
+@media (width >= 980px) {
+    .blog div.section > div:not(.hero-wrapper, .related-articles-wrapper, .blog-cta-banner-wrapper) {
+        width: 755px; /* Option A */
+        max-width: 755px;  /* Option A */
     }
 
-    /* Blog: desktop view: cta-banner align left */
+        /* Blog: desktop view: cta-banner align left */
     .blog .blog-cta-banner.alignleft {
         float:left;
         width: 370px;
-        margin-left: -92.5px;
+        margin-left: -20px; /* missing design, assumption */
         margin-top: 0;
         margin-right: 2rem;
-        margin-bottom: 3rem;
     }
 }


### PR DESCRIPTION
This is global styling, iteration 1. A lot of design information is missing and has been requested from SAP, see https://github.com/urfuwo/hlx-test/issues/72. When that information becomes available, it will be incorporated using a separate GH issue. Stylings that are based on assumptions have been marked as such.

Note: the header did not render, so I could not validate it. Sorry if I messed up your header, @saurabh-khare

Changes made:

Global styles have been extracted from https://www.figma.com/file/oSetT4LbatRmXlcB2A7V8Z/Content-Hubs-2024?type=design&node-id=269-30889&mode=design&t=d8vHtgahsV4EkVVv-0 

Media queries:
Replaced all @media query sizes with 3 UDex breakpoints:
- 640px (--udexGridSMinWidth)
- 980px (--udexGridMMinWidth)
- 1600px (--udexGridXLMinWidth), header only)
Media queries are supposed to be min-width (ref: https://www.aem.live/docs/dev-collab-and-good-practices#breakpoints), but lint requires them to be context queries (https://stylelint.io/user-guide/rules/media-feature-range-notation/#context)

Margins left/right do not apply to header or footer

I had to make changes to stylesheets outside styles.css. Sorry for that if I broke your styles. I validated on the following pages:
- http://localhost:3000/blog/2023/11/supply-chain-issues-keeping-ceos-up-at-night
- http://localhost:3000/tags/generative-ai 

No styling has been applied to elements like:
- cta-banner, related articles (must be defined in articles.css)
- hero banner (styling is expected to come from the web component)
- header, footer

Fix #40

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/supply-chain-issues-keeping-ceos-up-at-night
- After: https://40-global-styling--hlx-test--urfuwo.hlx.live/blog/2023/11/supply-chain-issues-keeping-ceos-up-at-night
