### PR TITLE
[do not merge] Fix jumpy article pages using CSS grid (wait for GH #116)

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -1,22 +1,3 @@
-main .hero-container > div {
-  max-width: unset;
-}
-
-/* XL: full width, ignore grid */
-@media (width >= 1600px) {
-  main .hero-container > .hero-wrapper {
-    /* TODO: workaround for sidenav iteration, to be changed with grid implementation */
-    width: 100%;
-    position: relative;
-    left: 50%;
-    right: 50%;
-
-    /* TODO: workaround for sidenav iteration, to be changed with grid implementation */
-    margin-left: calc(-50vw + 375px);
-    margin-right: -50vw;
-  }
-}
-
 main .hero-container {
   /* do not change padding-bottom */
   padding-left: 0;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -146,6 +146,30 @@ async function loadEager(doc) {
 }
 
 /**
+ * The use of CSS Grids makes certain assumptions that require a (per-template) DOM restructuring
+ * This change will be superseded by GH #116
+ * See templates/<template>/cssgrid.js
+ * @param main
+ * @returns {Promise<void>}
+ */
+async function restructureForCSSGrid(main) {
+  try {
+    const template = toClassName(getMetadata('template'));
+    const templates = Object.keys(TEMPLATE_LIST);
+    if (templates.includes(template)) {
+      const templateName = TEMPLATE_LIST[template];
+      const mod = await import(`../templates/${templateName}/cssgrid.js`);
+      if (mod.default) {
+        await mod.default(main);
+      }
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Template CSS Grid decoration failed', error);
+  }
+}
+
+/**
  * Loads everything that doesn't need to be delayed.
  * @param {Element} doc The container element
  */
@@ -159,6 +183,8 @@ async function loadLazy(doc) {
 
   loadHeader(doc.querySelector('header'));
   loadFooter(doc.querySelector('footer'));
+
+  restructureForCSSGrid(main);
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();

--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -39,10 +39,11 @@
 
 .article.appear {
   display: grid;
-  /* grid-template-columns: 3fr 6fr 3fr; */
+  grid-template-columns: 1fr;
   grid-template-areas:
     'header'
     'sidenav'
+    'hero'
     'main'
     'info'
     'footer';
@@ -54,6 +55,7 @@
     grid-template-columns: 3fr 6fr 3fr;
     grid-template-areas:
       'header header header'
+      'hero hero hero'
       'sidenav main .'
       'info info info'
       'footer footer footer';
@@ -79,10 +81,24 @@ div.header.block {
   display: contents;
 }
 
-main > .hero-container {
+main div.section {
+  display: contents;
+}
+
+main div.section div.hero-wrapper {
+  grid-area: hero;
+}
+
+main div.section.related-articles-container {
+  display: block;
+  grid-area: info;
+}
+
+main div.body-grid-area {
+  display: block;
   grid-area: main;
 }
 
-main > .related-articles-container {
+main div.related-content-grid-area {
   grid-area: info;
 }

--- a/templates/article/cssgrid.js
+++ b/templates/article/cssgrid.js
@@ -1,0 +1,45 @@
+import { div } from '../../scripts/dom-builder.js';
+
+/**
+ * Move all non-hero banner and non-related content sections into a dedicated wrapper
+ * Move all related content sections into a dedicated wrapper
+ * Expected Result: Areas that contain a single section (hero, pagenav, rightcolumn) are
+ * direct children of main, while
+ * all text body sections are wrapped in a container 'textbody-grid-area' and
+ * all related content sections are wrapped in a container 'related-content-grid-area'
+ * @param main
+ */
+export default function adaptForMultiSectionCSSGrid(main) {
+  /* Extract the hero section into its own section */
+  let extractedHeroSection = null;
+  const heroWrapper = main.querySelector(':scope > div.section.hero-container > .hero-wrapper');
+  if (heroWrapper) {
+    const existingHeroSection = heroWrapper.parentNode;
+    extractedHeroSection = div({ class: 'section hero-container' });
+    extractedHeroSection.append(heroWrapper);
+    existingHeroSection.classList.remove('hero-container');
+  }
+  /* Extract the related content sections into its own area */
+  const rcSectionsGridArea = div({ class: 'related-content-grid-area' });
+  main.querySelectorAll(':scope > div.section.related-articles-container').forEach((rc) => {
+    rcSectionsGridArea.append(rc);
+  });
+  const bodyGridArea = div({ class: 'body-grid-area' });
+  main.querySelectorAll(':scope > div.section').forEach((section) => {
+    bodyGridArea.append(section);
+  });
+  /* Finally */
+  /* Add the hero section back in */
+  if (extractedHeroSection) {
+    main.append(extractedHeroSection);
+  }
+  if (bodyGridArea.hasChildNodes()) {
+    main.append(bodyGridArea);
+  }
+  /* Add the related-content grid-area back in */
+  if (rcSectionsGridArea.hasChildNodes()) {
+    main.append(rcSectionsGridArea);
+  } else {
+    rcSectionsGridArea.remove();
+  }
+}


### PR DESCRIPTION
**Don't merge**

fix: temporary fix for CSS grids on article pages

This temporary fix shall be superseded by #116

Fix #141

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
- After: https://141-stop-the-jumpy-page-layouts--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
