### PR TITLE
chore: Hero (media blend) - Use 'picture' in additionalContent slot

### DIFF
--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -54,7 +54,7 @@ export default async function decorate(block) {
       slot: 'additionalContent',
       class: ['hero-banner', 'media-blend__additional-content'],
     },
-    img,
+    picture,
   );
   hero.appendChild(additionalContentSlot);
 

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -47,7 +47,6 @@ export default async function decorate(block) {
   const picture = block.querySelector('picture');
   const img = picture.querySelector('img');
   img.classList.add('custom-background-image');
-  img.setAttribute('loading', 'eager');
 
   const additionalContentSlot = div(
     {


### PR DESCRIPTION
Test URLs:
- Before: https://main-picture--hlx-test--urfuwo.hlx.live/draft/satyam/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
- After: https://hero-picture--hlx-test--urfuwo.hlx.live/draft/satyam/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation | Library Link
------------- | -------------|----------------
social | [doc-link](https://sap.sharepoint.com/sites/207899/_layouts/15/doc.aspx?sourcedoc={5c2d8d7b-f6d5-4356-b71c-3730ad5886db}&action=edit) | [Library Link](https://social--hlx-test--urfuwo.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/social&index=1)


- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. hero (light)  | [doc-link](https://sap.sharepoint.com/:w:/r/sites/207899/_layouts/15/Doc.aspx?sourcedoc=%7B0B62F23A-5C8F-4C2D-BA2E-C444D3631B51%7D&file=hero.docx&action=default&mobileredirect=true)
