### PR TITLE
Article-Intro block (styling only; no importer logic)

### DIFF
--- a/blocks/article-intro/article-intro.css
+++ b/blocks/article-intro/article-intro.css
@@ -1,0 +1,17 @@
+/* article intro block styling */
+.article-intro {
+  font-size: var(--udexTypographyBodyMFontSize);
+  font-family: var(--udexTypographyBodyMFontFamily);
+  font-weight: var(--udexTypographyBodyMFontWeight);
+  line-height: var(--udexTypographyBodyMLineHeight);
+}
+
+/* breakpoint M and larger */
+@media (width >= 980px) {
+  .article-intro {
+    font-size: var(--udexTypographyBodyLFontSize);
+    font-family: var(--udexTypographyBodyLFontFamily);
+    font-weight: var(--udexTypographyBodyLFontWeight);
+    line-height: var(--udexTypographyBodyLLineHeight);
+  }
+}

--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -8,15 +8,6 @@
   margin-bottom: 18px; /* no design, assumption */
 }
 
-/* Highlight first paragraph of blog pages using increased font size */
-.article
-  main
-  > div:first-child
-  > div.default-content-wrapper:nth-child(2)
-  > p:first-child {
-  font-size: var(--udexTypographyBodyLFontSize); /* no design, assumption */
-}
-
 /* Desktop view (--udexGridMMinWidth) */
 @media (width >= 980px) {
   .article
@@ -40,7 +31,7 @@
 
 .article.appear {
   display: grid;
-  
+
   /* grid-template-columns: 3fr 6fr 3fr; */
   grid-template-areas:
     'header'


### PR DESCRIPTION
fix: article-intro styling
fix: removed the existing first-paragraph highlighting logic

not included: importer logic (provided by @mhaack in a separate branch)

Fix #142

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
- After: https://142-article-intro-block--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications

- [X] New Blocks introduced in this PR

Block Name    | Documentation | Library Link
------------- | -------------|----------------
article-intro | [doc-link](https://sap.sharepoint.com/:w:/r/sites/207899/Shared%20Documents/website/tools/sidekick/blocks/article-intro.docx?d=w61eb994a5d634eaf9c91c9d11062d60d&csf=1&web=1&e=okBO7c) | [Library Link](https://main--hlx-test--urfuwo.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/article-intro&index=0)

