### PR TITLE
Added styles for image/video caption on article pages

### DIFF
--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -72,3 +72,13 @@ main {
     margin-inline: var(--udexGridMargins);
   }
 }
+
+/* image and video caption */
+.article p>em {
+  font-size: var(--udexTypographyBodyXSFontSize);
+  font-family: var(--udexTypographyBodyXSFontFamily);
+  line-height: var(--udexTypographyBodyXSLineHeight);
+  font-weight: var(--udexTypographyBodyXSFontWeight);
+  font-style: normal;
+  color: var(--udexColorGrey9);
+}


### PR DESCRIPTION
Fix #117

Added styling for article image and video captions.

Test URLs:
- Before:https://main--hlx-test--urfuwo.hlx.page/news/0000/the-article
- After: https://117-implement-styling-for-image-caption--hlx-test--urfuwo.hlx.page/news/0000/the-article

- [ ] New Blocks introduced in this PR

- [ ] New variations introduced in this PR
