### PR TITLE
chore: Main content must remain centered on XL devices

### DIFF
--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -55,6 +55,7 @@ main {
   & > .toc-container {
     grid-area: toc;
     margin-inline-start: var(--udexGridMargins);
+    transition: margin-inline-start 0.3s ease-in-out;
   }
 
   & > .article-intro-container {
@@ -65,17 +66,20 @@ main {
   &:not(:has(.toc-container)) {
     & > .article-intro-container {
       margin-inline-start: var(--udexGridMargins);
+      transition: margin-inline-start 0.3s ease-in-out;
     }
   }
 
   & > :nth-last-child(2) {
     grid-area: promo;
     margin-inline-end: var(--udexGridMargins);
+    transition: margin-inline-end 0.3s ease-in-out;
   }
 
   & > .related-articles-container {
     grid-area: relatedinfo;
     margin-inline: var(--udexGridMargins);
+    transition: margin-inline 0.3s ease-in-out;
   }
 }
 

--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -26,6 +26,13 @@ main {
     }
   }
 
+  & > * {
+    transition-property: margin-inline-start, margin-inline-end, margin-inline,
+      margin-block-end;
+    transition-duration: 0.3s;
+    transition-timing-function: ease-in-out;
+  }
+
   @media (width >= 980px) {
     /* if page has table of contents it has a 3 column layout */
     &:has(.toc-container) {
@@ -55,7 +62,6 @@ main {
   & > .toc-container {
     grid-area: toc;
     margin-inline-start: var(--udexGridMargins);
-    transition: margin-inline-start 0.3s ease-in-out;
   }
 
   & > .article-intro-container {
@@ -66,20 +72,17 @@ main {
   &:not(:has(.toc-container)) {
     & > .article-intro-container {
       margin-inline-start: var(--udexGridMargins);
-      transition: margin-inline-start 0.3s ease-in-out;
     }
   }
 
   & > :nth-last-child(2) {
     grid-area: promo;
     margin-inline-end: var(--udexGridMargins);
-    transition: margin-inline-end 0.3s ease-in-out;
   }
 
   & > .related-articles-container {
     grid-area: relatedinfo;
     margin-inline: var(--udexGridMargins);
-    transition: margin-inline 0.3s ease-in-out;
   }
 }
 

--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -4,6 +4,12 @@
   margin-bottom: 18px; /* no design, assumption */
 }
 
+@media (width >= 1600px) {
+  main {
+    --udexGridMargins: 246px;
+  }
+}
+
 main {
   display: grid;
   grid-auto-flow: row;
@@ -74,7 +80,7 @@ main {
 }
 
 /* image and video caption */
-.article p>em {
+.article p > em {
   font-size: var(--udexTypographyBodyXSFontSize);
   font-family: var(--udexTypographyBodyXSFontFamily);
   line-height: var(--udexTypographyBodyXSLineHeight);


### PR DESCRIPTION
Main content must be aligned with top nav margins so it does not stretches in 1600px+ layouts  

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.page/news/0000/sap-source-to-pay-strategy-focuses-customer-success
- After: https://content-layout-on-xl--hlx-test--urfuwo.hlx.page/news/0000/sap-source-to-pay-strategy-focuses-customer-success

