### PR TITLE
111 in page table of contents

### DIFF
--- a/blocks/toc/toc.css
+++ b/blocks/toc/toc.css
@@ -43,7 +43,7 @@
         display: flex;
         min-height: var(--udexSpacer40);
 
-        &.active {
+        &[aria-current="true"] {
             color: var(--udexColorBlue7);
 
             >span {

--- a/blocks/toc/toc.css
+++ b/blocks/toc/toc.css
@@ -19,9 +19,6 @@
         list-style: none;
         padding: 0;
         margin: 0;
-    }
-
-    >ol {
         border-left: 1px solid var(--udexCoreDividerLight);
     }
 
@@ -35,8 +32,8 @@
         text-decoration: none;
         color: var(--udexColorNeutralBlack);
         align-self: center;
+        width: calc(100% - 3rem);
     }
-
 
     .toc-h3 {
         padding-left: 34px;

--- a/blocks/toc/toc.css
+++ b/blocks/toc/toc.css
@@ -1,0 +1,71 @@
+.toc-wrapper {
+    height: 100%;
+}
+
+.toc {
+    position: sticky;
+    top: var(--udexSpacer84);
+
+    h2 {
+        margin-top: 0;
+        margin-bottom: var(--udexSpacer32);
+        font-family: var(--udexTypographyHeadingMediumXXXXSFontFamily);
+        font-size: var(--udexTypographyHeadingMediumXXXXSFontSize);
+        font-weight: var(--udexTypographyHeadingMediumXXXXSFontWeight);
+        line-height: var(--udexTypographyHeadingMediumXXXXSLineHeight);
+    }
+
+    ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+    }
+
+    >ol {
+        border-left: 1px solid var(--udexCoreDividerLight);
+    }
+
+    .toc-h2,
+    .toc-h3 {
+        font-family: var(--udexTypographyNavigationMediumMFontFamily);
+        font-size: var(--udexTypographyNavigationMediumMFontSize);
+        font-weight: var(--udexTypographyNavigationMediumMFontWeight);
+        line-height: var(--udexTypographyNavigationMediumMLineHeight);
+        padding: 8px 16px 8px 30px;
+        text-decoration: none;
+        color: var(--udexColorNeutralBlack);
+        align-self: center;
+    }
+
+
+    .toc-h3 {
+        padding-left: 34px;
+    }
+
+    li {
+        display: flex;
+        min-height: var(--udexSpacer40);
+
+        &.active {
+            color: var(--udexColorBlue7);
+
+            >span {
+                display: inline-block;
+                width: 3px;
+                background-color: var(--udexColorBlue7);
+                border-radius: 0 4px 4px 0;
+                margin-left: -1px;
+            }
+
+            .toc-h2 {
+                color: var(--udexColorBlue7);
+                padding-left: 28px;
+            }
+
+            >.toc-h3 {
+                color: var(--udexColorBlue7);
+                padding-left: 32px;
+            }
+        }
+    }
+}

--- a/blocks/toc/toc.js
+++ b/blocks/toc/toc.js
@@ -1,5 +1,5 @@
 import {
-  h2, ol, li, span, a, domEl,
+  h2, ol, li, span, a, aside,
 } from '../../scripts/dom-builder.js';
 
 function setActiveLink() {
@@ -18,7 +18,7 @@ export default async function decorate(block) {
   const mainContent = document.querySelector('main > :nth-child(3)');
   const headers = mainContent?.querySelectorAll('h2, h3');
   if (headers.length > 0) {
-    const tocElement = domEl('aside', { class: 'toc' }, h2('What\'s on this page'));
+    const tocElement = aside({ class: 'toc' }, h2('What\'s on this page'));
     const tocList = ol();
     headers.forEach((header) => {
       const entry = li(

--- a/blocks/toc/toc.js
+++ b/blocks/toc/toc.js
@@ -1,0 +1,42 @@
+function createEntry(element) {
+  const listEl = document.createElement('li');
+  const spanEl = document.createElement('span');
+  listEl.append(spanEl);
+  const linkEl = document.createElement('a');
+  linkEl.href = `#${element.id}`;
+  linkEl.innerText = element.innerText;
+  linkEl.classList.add(`toc-${element.tagName.toLowerCase()}`);
+  listEl.append(linkEl);
+  return listEl;
+}
+
+export default async function decorate(block) {
+  const mainContent = document.querySelector('main > :nth-child(3)');
+  const headers = mainContent.querySelectorAll('h2, h3');
+  const tocElement = document.createElement('div');
+  const h2 = document.createElement('h2');
+  h2.innerText = 'What\'s on this page';
+  tocElement.appendChild(h2);
+  const tocList = document.createElement('ol');
+  headers.forEach((header) => {
+    const entry = createEntry(header);
+    tocList.appendChild(entry);
+  });
+  tocElement.appendChild(tocList);
+  tocElement.classList.add('toc');
+  block.append(tocElement);
+}
+
+function setActiveLink() {
+  const links = document.querySelectorAll('.toc li');
+  links.forEach((link) => {
+    const linkHash = link.querySelector('a').hash;
+    if (linkHash === window.location.hash) {
+      link.classList.add('active');
+    } else {
+      link.classList.remove('active');
+    }
+  });
+}
+window.addEventListener('load', setActiveLink);
+window.addEventListener('hashchange', setActiveLink);

--- a/blocks/toc/toc.js
+++ b/blocks/toc/toc.js
@@ -1,44 +1,38 @@
-function createEntry(element) {
-  const listEl = document.createElement('li');
-  const spanEl = document.createElement('span');
-  listEl.append(spanEl);
-  const linkEl = document.createElement('a');
-  linkEl.href = `#${element.id}`;
-  linkEl.innerText = element.innerText;
-  linkEl.classList.add(`toc-${element.tagName.toLowerCase()}`);
-  listEl.append(linkEl);
-  return listEl;
-}
-
-export default async function decorate(block) {
-  const mainContent = document.querySelector('main > :nth-child(3)');
-  const headers = mainContent?.querySelectorAll('h2, h3');
-  if (headers.length > 0) {
-    const tocElement = document.createElement('div');
-    const h2 = document.createElement('h2');
-    h2.innerText = 'What\'s on this page';
-    tocElement.appendChild(h2);
-    const tocList = document.createElement('ol');
-    headers.forEach((header) => {
-      const entry = createEntry(header);
-      tocList.appendChild(entry);
-    });
-    tocElement.appendChild(tocList);
-    tocElement.classList.add('toc');
-    block.append(tocElement);
-  }
-}
+import {
+  h2, ol, li, span, a, domEl,
+} from '../../scripts/dom-builder.js';
 
 function setActiveLink() {
   const links = document.querySelectorAll('.toc li');
   links.forEach((link) => {
     const linkHash = link.querySelector('a')?.hash;
     if (linkHash === window.location.hash) {
-      link.classList.add('active');
+      link.setAttribute('aria-current', 'true');
     } else {
-      link.classList.remove('active');
+      link.setAttribute('aria-current', 'false');
     }
   });
 }
-window.addEventListener('load', setActiveLink);
-window.addEventListener('hashchange', setActiveLink);
+
+export default async function decorate(block) {
+  const mainContent = document.querySelector('main > :nth-child(3)');
+  const headers = mainContent?.querySelectorAll('h2, h3');
+  if (headers.length > 0) {
+    const tocElement = domEl('aside', { class: 'toc' }, h2('What\'s on this page'));
+    const tocList = ol();
+    headers.forEach((header) => {
+      const entry = li(
+        span(),
+        a({
+          href: `#${header.id}`,
+          class: `toc-${header.tagName.toLowerCase()}`,
+        }, header.innerText),
+      );
+      tocList.appendChild(entry);
+    });
+    tocElement.appendChild(tocList);
+    block.append(tocElement);
+    window.addEventListener('load', setActiveLink);
+    window.addEventListener('hashchange', setActiveLink);
+  }
+}

--- a/blocks/toc/toc.js
+++ b/blocks/toc/toc.js
@@ -12,25 +12,27 @@ function createEntry(element) {
 
 export default async function decorate(block) {
   const mainContent = document.querySelector('main > :nth-child(3)');
-  const headers = mainContent.querySelectorAll('h2, h3');
-  const tocElement = document.createElement('div');
-  const h2 = document.createElement('h2');
-  h2.innerText = 'What\'s on this page';
-  tocElement.appendChild(h2);
-  const tocList = document.createElement('ol');
-  headers.forEach((header) => {
-    const entry = createEntry(header);
-    tocList.appendChild(entry);
-  });
-  tocElement.appendChild(tocList);
-  tocElement.classList.add('toc');
-  block.append(tocElement);
+  const headers = mainContent?.querySelectorAll('h2, h3');
+  if (headers.length > 0) {
+    const tocElement = document.createElement('div');
+    const h2 = document.createElement('h2');
+    h2.innerText = 'What\'s on this page';
+    tocElement.appendChild(h2);
+    const tocList = document.createElement('ol');
+    headers.forEach((header) => {
+      const entry = createEntry(header);
+      tocList.appendChild(entry);
+    });
+    tocElement.appendChild(tocList);
+    tocElement.classList.add('toc');
+    block.append(tocElement);
+  }
 }
 
 function setActiveLink() {
   const links = document.querySelectorAll('.toc li');
   links.forEach((link) => {
-    const linkHash = link.querySelector('a').hash;
+    const linkHash = link.querySelector('a')?.hash;
     if (linkHash === window.location.hash) {
       link.classList.add('active');
     } else {

--- a/scripts/dom-builder.js
+++ b/scripts/dom-builder.js
@@ -97,3 +97,4 @@ export function dl(...items) { return domEl('dl', ...items); }
 export function dt(...items) { return domEl('dt', ...items); }
 export function dd(...items) { return domEl('dd', ...items); }
 export function hr(...items) { return domEl('hr', ...items); }
+export function aside(...items) { return domEl('aside', ...items); }

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -12,6 +12,15 @@ function restructureArticle(container, targetClass) {
 function decorate(doc) {
   const main = doc.querySelector('main');
   restructureArticle(main, '.hero');
+  const tocFlag = document.querySelector('meta[name="toc"]');
+  if (tocFlag && tocFlag.content !== 'no' && tocFlag.content !== 'false') {
+    const tocSection = document.createElement('div');
+    const tocBlock = document.createElement('div');
+    tocSection.classList.add('toc-container');
+    tocBlock.classList.add('toc');
+    tocSection.appendChild(tocBlock);
+    main.insertBefore(tocSection, document.querySelector('main > :nth-child(2)'));
+  }
 }
 
 decorate(document);

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -15,9 +15,7 @@ function decorate(doc) {
   restructureArticle(main, '.hero');
   const tocFlag = getMetadata('toc');
   if (tocFlag && tocFlag.content !== 'no' && tocFlag.content !== 'false') {
-    const tocSection = div({ class: 'toc-container' });
-    const tocBlock = div({ class: 'toc' });
-    tocSection.appendChild(tocBlock);
+    const tocSection = div({ class: 'toc-container' }, div({ class: 'toc' }));
     main.insertBefore(tocSection, doc.querySelector('main > :nth-child(2)'));
   }
 }

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -1,4 +1,5 @@
 import { div } from '../../scripts/dom-builder.js';
+import { getMetadata } from '../../scripts/aem.js';
 
 function restructureArticle(container, targetClass) {
   const target = container.querySelector(targetClass);
@@ -12,14 +13,12 @@ function restructureArticle(container, targetClass) {
 function decorate(doc) {
   const main = doc.querySelector('main');
   restructureArticle(main, '.hero');
-  const tocFlag = document.querySelector('meta[name="toc"]');
+  const tocFlag = getMetadata('toc');
   if (tocFlag && tocFlag.content !== 'no' && tocFlag.content !== 'false') {
-    const tocSection = document.createElement('div');
-    const tocBlock = document.createElement('div');
-    tocSection.classList.add('toc-container');
-    tocBlock.classList.add('toc');
+    const tocSection = div({ class: 'toc-container' });
+    const tocBlock = div({ class: 'toc' });
     tocSection.appendChild(tocBlock);
-    main.insertBefore(tocSection, document.querySelector('main > :nth-child(2)'));
+    main.insertBefore(tocSection, doc.querySelector('main > :nth-child(2)'));
   }
 }
 


### PR DESCRIPTION
Fix #111

This introduces the side navigation / table of contents for L3 article pages.
As requested, it is a basic version that does not yet track the current position in the page to update the TOC but first focusses on the hash in the url to highlight the active part.

Please provide some feedback on the integration, as it this block renders at the same time as the hero, not subsequently as the remaining page (if that is the desired state?) LHS does not change / improves for desktop compared with the main branch.
Also, where & how do we document blocks that are generated by metadata like this one?

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.page/news/0000/the-article
- After: https://111-in-page-table-of-contents--hlx-test--urfuwo.hlx.page/news/0000/the-article

- [x] New Blocks introduced in this PR

Block Name    | Documentation | Library Link
------------- | -------------|----------------
toc | [doc-link](https://sap.sharepoint.com/:w:/r/sites/207899/_layouts/15/Doc.aspx?sourcedoc=%7BF661518B-AC56-470D-8C20-2CB83186CF6A%7D&file=toc.docx&action=default&mobileredirect=true) | [Library Link](https://main--hlx-test--urfuwo.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/toc&index=0)


- [ ] New variations introduced in this PR