### PR TITLE
Handling quote without author

### DIFF
--- a/blocks/quote/quote.js
+++ b/blocks/quote/quote.js
@@ -1,8 +1,12 @@
 export default function decorate(block) {
   const qtContent = block.querySelector(':scope > div:first-of-type > div');
+  const qsContent = block.querySelector(':scope > div:nth-of-type(2) > div');
   qtContent.classList.add('col', 'content');
   qtContent.parentNode.classList.add('qt');
-  const qsContent = block.querySelector(':scope > div:nth-of-type(2) > div');
-  qsContent.classList.add('col', 'content');
-  qsContent.parentNode.classList.add('qs');
+  if (qsContent) {
+    qsContent.classList.add('col', 'content');
+    qsContent.parentNode.classList.add('qs');
+  } else {
+    qtContent.parentNode.classList.add('qt single-qt');
+  }
 }


### PR DESCRIPTION
Fix #169

Supports missing author information / quote only.
Styling is different on the screenshot in Figma, so will probably have to adjusted once available.


Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.page/news/0000/the-article
- After: https://169-quote-block-should-have-quote-only-mode--hlx-test--urfuwo.hlx.page/news/0000/the-article

- [ ] New Blocks introduced in this PR
- [x] New variations introduced in this PR

Variation Name    | Documentation   | Library
------------- | ------------- | -------------
Quote without author  | [doc-link](https://sap.sharepoint.com/:w:/r/sites/207899/_layouts/15/Doc.aspx?sourcedoc=%7BA3B64EC2-D52A-4678-9579-CAA9AF162517%7D&file=quote.docx&action=default&mobileredirect=true)  | [Lib](https://169-quote-block-should-have-quote-only-mode--hlx-test--urfuwo.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/tools/sidekick/blocks/quote&index=3)
