### PR TITLE
Author Index: Add property description

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -51,3 +51,6 @@ indices:
       image:
         select: head > meta[property="og:image"]
         value: attribute(el, "content")
+      description:
+        select: head > meta[property="og:description"]
+        value: attribute(el, "content")


### PR DESCRIPTION
fix: added property description (og:description) from author profile docs to author index

Fix #197 

Changes:
- added column "description" to /authors-index.xlsx
- index definition updated: https://197-author-index-add-description-property--hlx-test--urfuwo.hlx.page/helix-query.yaml - property "description" added to index "author"

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
- After: https://197-author-index-add-description-property--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
