### PR TITLE
Author Index: add author profile doc property 'title' to index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -54,3 +54,6 @@ indices:
       description:
         select: head > meta[property="og:description"]
         value: attribute(el, "content")
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")


### PR DESCRIPTION
fix: added author profile doc property "title" to the author index

Fix #201

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
- After: https://201-author-index-add-title--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
