### PR TITLE
chore: adapt for meta data changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ helix-importer-ui
 .DS_Store
 *.bak
 .idea
+url.txt

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -41,11 +41,12 @@ export default async function decorate(block) {
         getMetadata('author'),
         ' •',
       ) : '',
-      getMetadata('article:published_time') ? span(
+      getMetadata('published-time') ? span(
         { class: ['media-blend__date'] },
-        formatDate(getMetadata('article:published_time')),
+        formatDate(getMetadata('published-time')),
         getMetadata('article:read_time') ? ' •' : '',
       ) : '',
+      // TODO this is wrong we don't have read time in metadata
       getMetadata('article:read_time') ? span(
         { class: ['media-blend__read-time'] },
         getMetadata('article:read_time'),

--- a/blocks/preflight/panels/seo.js
+++ b/blocks/preflight/panels/seo.js
@@ -95,7 +95,7 @@ function checkDescription() {
 }
 
 function checkPublishedDate() {
-  const pubDate = document.querySelector('meta[property="article:published_time"]');
+  const pubDate = document.querySelector('meta[published-time"]');
   const result = { icon: DEF_ICON, title: 'Published Date', description: DEF_DESC };
   if (!pubDate) {
     result.icon = fail;

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -33,10 +33,10 @@ indices:
         select: head > meta[property="og:image"]
         value: attribute(el, "content")
       lastModified:
-        select: head > meta[property="article:modified_time"]
+        select: head > meta[property="modified-time"]
         value: parseTimestamp(attribute(el, "content"))
       publicationDate:
-        select: head > meta[property="article:published_time"]
+        select: head > meta[property="published-time"]
         value: parseTimestamp(attribute(el, "content"))
   author:
     include:

--- a/scripts/schema.js
+++ b/scripts/schema.js
@@ -31,7 +31,7 @@ export function buildArticleSchema() {
     },
     headline: getMetadata('og:title'),
     image: getMetadata('og:image'),
-    datePublished: getMetadata('article:published_time'),
+    datePublished: getMetadata('published-time'),
     publisher: {
       '@type': 'Organization',
       name: 'SAP',
@@ -53,7 +53,7 @@ export function buildArticleSchema() {
     inLanguage: getMetadata('og:locale') || 'en',
   };
 
-  if (getMetadata('article:modified_time')) data.dateModified = getMetadata('article:modified_time');
+  if (getMetadata('modified-time')) data.dateModified = getMetadata('modified-time');
   if (getMetadata('author')) {
     data.author = {
       '@type': 'Person',


### PR DESCRIPTION
First part of metadata changes for new imported content.

Relates #200 

Test URLs:

* Before: https://main--hlx-test--urfuwo.hlx.live/blog/2019/06/save-coastal-wildlife-sap-employee-profile
* After: https://fix-for-import--hlx-test--urfuwo.hlx.live/blog/2019/06/save-coastal-wildlife-sap-employee-profile



