### PR TITLE
First draft

### DIFF
--- a/blocks/article-list/article-list.js
+++ b/blocks/article-list/article-list.js
@@ -1,5 +1,9 @@
 import {
-  createOptimizedPicture, getMetadata, toClassName, loadCSS, fetchPlaceholders,
+  createOptimizedPicture,
+  getMetadata,
+  toClassName,
+  loadCSS,
+  fetchPlaceholders,
 } from '../../scripts/aem.js';
 import {
   ul, li, a, span,
@@ -23,16 +27,13 @@ function renderCard(card) {
     ),
     span(
       { class: 'cardcontent' },
-      span({ class: 'template' }, card['content-type'].replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())),
-      (card['hot-story'] ? span({ class: 'hot' }, 'Hot Story') : ''),
       span(
-        { class: 'title' },
-        a({ href: card.path }, card.title),
+        { class: 'template' },
+        card['content-type'].replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
       ),
-      span(
-        { class: 'author' },
-        a({ href: cardAuthorUrl }, span(`${card.author}`)),
-      ),
+      card['hot-story'] ? span({ class: 'hot' }, 'Hot Story') : '',
+      span({ class: 'title' }, a({ href: card.path }, card.title)),
+      span({ class: 'author' }, a({ href: cardAuthorUrl }, span(`${card.author}`))),
       span({ class: 'date' }, formattedDate),
     ),
   );
@@ -63,7 +64,9 @@ function determineContextFilter() {
   // for tags get filter from URL
   if (window.location.pathname.startsWith('/tags/') > 0) {
     const tag = window.location.pathname.split('/')[2];
-    return (entry) => JSON.parse(entry.tags).map((t) => toClassName(t)).includes(tag);
+    return (entry) => JSON.parse(entry.tags)
+      .map((t) => toClassName(t))
+      .includes(tag);
   }
 
   // for everything else, filter by category
@@ -80,7 +83,9 @@ function determineContextFilter() {
 export default async function listArticles(block, config = { filter: null, maxEntries: null }) {
   loadCSS(`${window.hlx.codeBasePath}/blocks/article-list/article-list.css`);
 
-  const links = Array.from(block.querySelectorAll(':scope > div a')).map((link) => new URL(link.href).pathname);
+  const links = Array.from(block.querySelectorAll(':scope > div a')).map(
+    (link) => new URL(link.href).pathname,
+  );
   if (links.length > 0) {
     config.filter = (entry) => links.includes(entry.path);
     config.sorting = (l, r) => links.indexOf(l.path) - links.indexOf(r.path);

--- a/blocks/related-articles/related-articles.css
+++ b/blocks/related-articles/related-articles.css
@@ -1,28 +1,31 @@
 .read-more h3 {
-    font-size: var(--udexTypographyHeadingRegularLFontSize);
-    font-family: var(--udexTypographyHeadingRegularLFontFamily);
-    font-weight: var(--udexTypographyHeadingRegularLFontWeight);
-    line-height: var(--udexTypographyHeadingRegularLLineHeight);
-    
-    --webkit-font-smoothing: antialiased;
+  font-size: var(--udexTypographyHeadingRegularLFontSize);
+  font-family: var(--udexTypographyHeadingRegularLFontFamily);
+  font-weight: var(--udexTypographyHeadingRegularLFontWeight);
+  line-height: var(--udexTypographyHeadingRegularLLineHeight);
+
+  --webkit-font-smoothing: antialiased;
 }
 
-main ul.article-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(278px, 1fr));
-    grid-gap: 16px;
+.article-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(278px, 1fr));
+  grid-gap: var(--udexGridGutters);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  --article-tile-height: auto;
+
+  @media (width >= 640px) {
+    & {
+      grid-template-columns: repeat(2, 1fr);
+    }
   }
-  
-  main ul.article-list>li {
-    border: 1px solid var(--dark-color);
-    background-color: var(--background-color)
+
+  @media (width >= 980px) {
+    & {
+      grid-template-columns: repeat(3, 1fr);
+    }
   }
-  
-  main ul.article-list>li img {
-    width: 100%;
-    aspect-ratio: 4 / 3;
-    object-fit: cover;
-  }
+}

--- a/blocks/related-articles/related-articles.js
+++ b/blocks/related-articles/related-articles.js
@@ -1,10 +1,33 @@
-import { div } from '../../scripts/dom-builder.js';
-import listArticles from '../article-list/article-list.js';
+import { ul } from '../../scripts/dom-builder.js';
+import { getMetadata } from '../../scripts/aem.js';
+import ffetch from '../../scripts/ffetch.js';
+import PictureCard from '../../libs/pictureCard/pictureCard.js';
+
+function getFilter(pageTags) {
+  return (entry) => {
+    const entryTags = JSON.parse(entry.tags);
+    if (Array.isArray(entryTags) && entryTags.length > 0) {
+      return pageTags.some((item) => entryTags.includes(item));
+    }
+    return false;
+  };
+}
 
 export default async function decorateBlock(block) {
-  const articles = div();
-  listArticles(articles, { filter: null, maxEntries: 3 });
+  const pageTags = getMetadata('article:tag').split(',');
+  const filter = getFilter(pageTags);
+  const limit = 3; // hardcoded for now
+  const articleStream = await ffetch('/articles-index.json').filter(filter).limit(limit).all();
+
+  const cardList = ul({ class: 'article-list' });
+  articleStream.forEach((article) => {
+    const {
+      author, 'content-type': type, image, path, title,
+    } = article;
+    const card = new PictureCard(title, type, path, type, author, image, '', '');
+    cardList.append(card.render());
+  });
 
   block.textContent = '';
-  block.append(articles);
+  block.append(cardList);
 }

--- a/libs/card/card.js
+++ b/libs/card/card.js
@@ -1,0 +1,34 @@
+import {
+    li, a, span,
+  } from '../../scripts/dom-builder.js';
+
+export default class Card {
+    constructor(title, subtitle, path, type){
+        this.title = title;
+        this.subtitle = subtitle;
+        this.path = path;
+        this.type = type;
+    }
+
+    getType() {
+        return this.type?.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+    }
+
+    render() {
+        return li(
+            { class: 'card' },
+            a(
+            { href: this.path, 'aria-label': this.title }
+            ),
+            span(
+            { class: 'cardcontent' },
+            span(
+                { class: 'type' },
+                this.getType(),
+            ),
+            span({ class: 'title' }, a({ href: this.path}, this.title)),
+            span({ class: 'subtitle' }, this.subtitle),
+            ),
+        );
+    }
+}

--- a/libs/pictureCard/pictureCard.css
+++ b/libs/pictureCard/pictureCard.css
@@ -1,0 +1,115 @@
+.card {
+  border: 1px solid var(--udexColorGrey2);
+  box-shadow: 0 2px 4px rgb(34 54 73 / 20%);
+  background-color: var(--background-color);
+  height: var(--article-tile-height);
+  border-radius: var(--sapTile_BorderCornerRadius);
+  overflow: hidden;
+  position: relative;
+
+  & img {
+    width: 100%;
+    height: 130px;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+  }
+
+  & .cardcontent {
+    display: block;
+    padding: var(--udexSpacer16);
+
+    & .template {
+      font-style: normal;
+      font-family: var(--udexTypographyBodyXSFontFamily);
+      font-weight: var(--udexTypographyDisplayMediumXSFontWeight);
+      font-size: var(--udexTypographyBodyXSFontSize);
+      line-height: var(--udexTypographyEyebrowMLineHeight);
+      display: flex;
+      align-items: center;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+      color: var(--udexColorGrey6);
+      flex: var(--sapContent_ForcedColorAdjust);
+      order: var(--sapShell_BackgroundImageOpacity);
+      flex-grow: var(--sapShell_BackgroundImageOpacity);
+      margin-bottom: var(--udexSpacer8);
+    }
+
+    & .hot {
+      position: absolute;
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+      padding: 4px 8px;
+      gap: 10px;
+      height: var(--udexTypographyHeadingRegularXSLineHeight);
+      right: var(--udexRadiusM);
+      top: var(--udexRadiusM);
+      background: var(--udexColorBlue1);
+      border: 1px solid #0070f2;
+      border-radius: var(--udexRadiusS);
+      font-family: var(--udexTypographyBodyXXSFontFamily);
+      font-weight: var(--udexTypographyBodyXXSFontWeight);
+      font-size: var(--udexGridXSColumns);
+      line-height: var(--udexCoreSizeIconInput);
+      text-align: center;
+      color: var(--udexColorBlue9);
+      flex: var(--sapContent_ForcedColorAdjust);
+      order: 0;
+      flex-grow: 0;
+    }
+
+    & .title {
+      display: block;
+
+      & a {
+        font-family: var(--udexTypographyBodyXXSFontFamily);
+        font-style: normal;
+        text-decoration: none;
+        font-weight: var(--udexTypographyDisplayMediumXSFontWeight);
+        font-size: var(--udexSpacer20);
+        line-height: var(--udexTypographyHeadingRegularXXSLineHeight);
+        color: var(--udexColorNeutralBlack);
+        flex: var(--sapContent_ForcedColorAdjust);
+        order: var(--sapShell_BackgroundImageOpacity);
+        align-self: stretch;
+        flex-grow: 0;
+        margin-bottom: 12px;
+      }
+    }
+
+    & .author {
+      display: block;
+
+      & a {
+        font-family: var(--udexTypographyBodyXSFontFamily);
+        font-style: normal;
+        text-decoration: none;
+        font-weight: var(--udexTypographyDisplayMediumXSFontWeight);
+        font-size: var(--udexTypographyBodyXSFontSize);
+        line-height: var(--udexTypographyEyebrowMLineHeight);
+        color: var(--udexColorNeutralBlack);
+        flex: var(--sapContent_ForcedColorAdjust);
+        order: 0;
+        align-self: stretch;
+        flex-grow: 0;
+      }
+    }
+
+    & .date {
+      display: block;
+      font-family: var(--udexTypographyBodyXXSFontFamily);
+      font-style: normal;
+      font-weight: var(--udexTypographyBodyXXSFontWeight);
+      font-size: var(--udexGridXSColumns);
+      line-height: var(--udexCoreSizeIconInput);
+      color: var(--udexColorGrey6);
+      flex: var(--sapContent_ForcedColorAdjust);
+      order: var(--sapShell_BackgroundImageOpacity);
+      align-self: stretch;
+      flex-grow: 0;
+    }
+  }
+}

--- a/libs/pictureCard/pictureCard.js
+++ b/libs/pictureCard/pictureCard.js
@@ -1,0 +1,58 @@
+import Card from "../card/card.js";
+import {
+    li, a, span,
+  } from '../../scripts/dom-builder.js';
+  import { createOptimizedPicture, toClassName, loadCSS } from '../../scripts/aem.js';
+
+export default class PictureCard extends Card {
+    constructor(title, subtitle, path, type, author, image, label, date){
+        super(title, subtitle, path, type);
+        this.author = author;
+        this.image = image;
+        this.label = label;
+        this.date = date;
+        loadCSS(`${window.hlx.codeBasePath}/libs/pictureCard/pictureCard.css`)
+    }
+
+    getAuthorUrl(){
+        return `/author/${toClassName(this.author).replace('-', '')}`;
+    }
+
+    getOptimizedPicture(){
+        return createOptimizedPicture(this.image, this.title, false, [{ width: '750' }]);
+    }
+
+    getLabel(){
+        return this.label ? span({ class: 'hot' }, 'Hot Story') : ''
+    }
+
+    getFormattedDate(){
+        const ARTICLE_FORMATTER = new Intl.DateTimeFormat('default', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+          });
+        return ARTICLE_FORMATTER.format(new Date(this.date * 1000));
+    }
+
+    render() {
+        return li(
+            { class: 'card' },
+            a(
+              { href: this.path, 'aria-label': this.title },
+              this.getOptimizedPicture(),
+            ),
+            span(
+              { class: 'cardcontent' },
+              span(
+                { class: 'template' },
+                this.getType(),
+              ),
+              this.getLabel(),
+              span({ class: 'title' }, a({ href: this.path }, this.title)),
+              span({ class: 'author' }, a({ href: this.getAuthorUrl() }, span(`${this.author}`))),
+              span({ class: 'date' }, this.getFormattedDate()),
+            ),
+          );
+    }
+}


### PR DESCRIPTION
1. Decoupled related articles. Removed call to article-list
2. Fetching and filtering logic in the block (related articles) itself
3. Card rendering and styling consolidated in card itself. The container here in this case related articles only need to arrange the cards. It is possible to override card style in container as well.

Fix #150 

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
- After: https://150-content-list-refactoring--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications

