### PR TITLE
Add publication / update dates to hero and footnote

### DIFF
--- a/blocks/article-footnote/article-footnote.css
+++ b/blocks/article-footnote/article-footnote.css
@@ -10,6 +10,10 @@
   margin-bottom: var(--udexSpacer56);
 }
 
+.article-footnote > div > div:last-of-type {
+  margin-top: var(--udexSpacer16);
+}
+
 .article-footnote p:first-of-type {
   margin-top: 0;
 }

--- a/blocks/article-footnote/article-footnote.css
+++ b/blocks/article-footnote/article-footnote.css
@@ -9,3 +9,11 @@
   border-top: 1px solid var(--udexColorGrey3);
   margin-bottom: var(--udexSpacer56);
 }
+
+.article-footnote p:first-of-type {
+  margin-top: 0;
+}
+
+.article-footnote p:last-of-type {
+  margin-bottom: 0;
+}

--- a/blocks/article-footnote/article-footnote.js
+++ b/blocks/article-footnote/article-footnote.js
@@ -1,12 +1,11 @@
-import { div, p } from '../../scripts/dom-builder.js';
+import { div } from '../../scripts/dom-builder.js';
 import { getMetadata } from '../../scripts/aem.js';
 import { formatDate } from '../../scripts/utils.js';
 
 export default async function decorateBlock(block) {
-  const content = block.firstElementChild.firstElementChild;
   const meta = [
     getMetadata('published-time') ? `Published on ${formatDate(getMetadata('published-time'))}` : null,
     getMetadata('modified-time') ? `Updated on ${formatDate(getMetadata('modified-time'))}` : null,
   ];
-  content.replaceWith(div(p(content.textContent), p(meta.filter(Boolean).join('. '))));
+  block.firstElementChild.append(div(meta.filter(Boolean).join('. ')));
 }

--- a/blocks/article-footnote/article-footnote.js
+++ b/blocks/article-footnote/article-footnote.js
@@ -1,0 +1,12 @@
+import { div, p } from '../../scripts/dom-builder.js';
+import { getMetadata } from '../../scripts/aem.js';
+import { formatDate } from '../../scripts/utils.js';
+
+export default async function decorateBlock(block) {
+  const content = block.firstElementChild.firstElementChild;
+  const meta = [
+    getMetadata('published-time') ? `Published on ${formatDate(getMetadata('published-time'))}` : null,
+    getMetadata('modified-time') ? `Updated on ${formatDate(getMetadata('modified-time'))}` : null,
+  ];
+  content.replaceWith(div(p(content.textContent), p(meta.filter(Boolean).join('. '))));
+}

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -132,12 +132,14 @@ udex-hero-banner#media-blend .media-blend__info-block {
   margin: var(--udexSpacer12, 12px) 0;
 }
 
-udex-hero-banner#media-blend .media-blend__info-block span {
-  margin: 0 var(--udexSpacer4);
+udex-hero-banner#media-blend .media-blend__info-block span::after {
+  margin: var(--udexSpacer4);
+  content: '•';
 }
 
-udex-hero-banner#media-blend .media-blend__info-block span:first-of-type {
-  margin-left: 0;
+udex-hero-banner#media-blend .media-blend__info-block span:last-of-type::after {
+  margin: 0;
+  content: '';
 }
 
 udex-hero-banner#media-blend .media-blend__buttons {

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -23,6 +23,8 @@ export default async function decorate(block) {
   const intro = block.querySelector('h6');
   const heading = block.querySelector('h1');
   const description = getDescription(block);
+  const lastUpdate = getMetadata('modified-time')
+    ? getMetadata('modified-time') : getMetadata('published-time');
   const contentSlot = div(
     {
       slot: 'content',
@@ -39,12 +41,10 @@ export default async function decorate(block) {
       getMetadata('author') ? span(
         { class: ['media-blend__author'] },
         getMetadata('author'),
-        ' •',
       ) : '',
-      getMetadata('published-time') ? span(
+      lastUpdate ? span(
         { class: ['media-blend__date'] },
-        formatDate(getMetadata('published-time')),
-        getMetadata('article:read_time') ? ' •' : '',
+        `Updated on ${formatDate(lastUpdate)}`,
       ) : '',
       // TODO this is wrong we don't have read time in metadata
       getMetadata('article:read_time') ? span(


### PR DESCRIPTION
fix: article-footnote: added published and updated time entries, delimited by dot
fix: hero: added single updated time entry (which uses either modified-time or - as a fallback - published-time)
chore: replaced dot separators in hero with ::after content

Fix #221

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.page/news/0000/the-article
- After: https://221-dates-in-hero-footnote--hlx-test--urfuwo.hlx.live/news/0000/the-article

Validation cases:
- /draft/hupe/221-article-published - only published date is set
- /draft/hupe/221-article-published-updated - published and modified/update dates are set
- /draft/hupe/221-article-updated - only modified/updated date is set
- /draft/hupe/221-article-neither-published-not-updated - neither published nor updated/modified date is set