### PR TITLE
chore: fixing date format and placeholder for related articles

### DIFF
--- a/blocks/content-list/content-list.js
+++ b/blocks/content-list/content-list.js
@@ -4,6 +4,7 @@ import { ul } from '../../scripts/dom-builder.js';
 import PictureCard from '../../libs/pictureCard/pictureCard.js';
 import Card from '../../libs/card/card.js';
 import Button from '../../libs/button/button.js';
+import { formatDate } from '../../scripts/utils.js';
 
 function matchTags(entry, config) {
   if (!config.tags) return true;
@@ -42,12 +43,7 @@ function getPlaceHolderValue(key, placeholders) {
 function getInfo(article, config) {
   const { info = ['publicationDate'] } = config;
   if (info[0] === 'publicationDate') {
-    const ARTICLE_FORMATTER = new Intl.DateTimeFormat('default', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-    return ARTICLE_FORMATTER.format(new Date(article.publicationDate * 1000));
+    return formatDate(article.publicationDate * 1000);
   }
   if (info[0] === 'author') {
     return article.author;

--- a/blocks/related-articles/related-articles.js
+++ b/blocks/related-articles/related-articles.js
@@ -1,7 +1,8 @@
 import { ul } from '../../scripts/dom-builder.js';
-import { getMetadata } from '../../scripts/aem.js';
+import { getMetadata, fetchPlaceholders, toCamelCase } from '../../scripts/aem.js';
 import ffetch from '../../scripts/ffetch.js';
 import PictureCard from '../../libs/pictureCard/pictureCard.js';
+import { formatDate } from '../../scripts/utils.js';
 
 function getFilter(pageTags) {
   return (entry) => {
@@ -14,6 +15,20 @@ function getFilter(pageTags) {
   };
 }
 
+function getPlaceHolderValue(key, placeholders) {
+  const value = placeholders[toCamelCase(key)];
+  return value || '';
+}
+
+function getPictureCard(article, placeholders) {
+  const {
+    author, 'content-type': type, image, path, title, priority,
+  } = article;
+  const tagLabel = getPlaceHolderValue(priority, placeholders);
+  const info = formatDate(article.publicationDate * 1000);
+  return new PictureCard(title, path, type, info, author, image, tagLabel);
+}
+
 export default async function decorateBlock(block) {
   const pageTags = getMetadata('article:tag').split(',');
   const filter = getFilter(pageTags);
@@ -23,13 +38,10 @@ export default async function decorateBlock(block) {
     .limit(limit)
     .slice(0, limit - 1)
     .all();
+  const placeholders = await fetchPlaceholders();
   const cardList = ul();
   articleStream.forEach((article) => {
-    const {
-      author, 'content-type': type, image, path, title, publicationDate, priority,
-    } = article;
-    const label = priority === 'hot-topic' ? 'Hot Story' : '';
-    const card = new PictureCard(title, path, type, label, author, image, publicationDate);
+    const card = getPictureCard(article, placeholders);
     cardList.append(card.render());
   });
 


### PR DESCRIPTION
- Date format must be same across article cards and hero block. As of now Hero block was showing US format while article cards show DD MM YYYY
- Also related articles will use placeholders to get tag labels

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
- After: https://fix-date-formatting--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
