### PR TITLE
239 Remove default role 'Author' and don't render anything if no authors are found

### DIFF
--- a/blocks/author-profile/author-profile.js
+++ b/blocks/author-profile/author-profile.js
@@ -20,7 +20,7 @@ function extractAuthorDescription(entry) {
         description = entry.title.substring(entry.author.length + 2);
       }
     } else {
-      description = 'Author';
+      description = '';
     }
   }
   return description;
@@ -34,10 +34,11 @@ function completeEntry(entry) {
 
 async function getAuthorEntry(entryFilter) {
   const result = await ffetch('/authors-index.json').filter(entryFilter).limit(1).all();
-  return completeEntry((!result || result.length < 1) ? null : result[0]);
+  return (!result || result.length < 1) ? null : completeEntry(result[0]);
 }
 
 function renderProfile(entry) {
+  if (!entry) return null;
   const authorImage = entry.image
     ? createOptimizedPicture(entry.image, entry.author, false, breakpoints) : null;
   const authorProfile = div(
@@ -62,9 +63,13 @@ export default async function decorate(block) {
   const name = getMetadata('author');
   const entryFilter = ((entry) => entry.author === name);
   const entry = await getAuthorEntry(entryFilter);
-  const authorProfile = await renderProfile(entry);
-  block.classList.add('ver');
-  block.append(authorProfile);
+  if (entry) {
+    const authorProfile = await renderProfile(entry);
+    block.classList.add('ver');
+    block.append(authorProfile);
+  } else {
+    block.parentNode.remove();
+  }
 }
 
 export {

--- a/blocks/author-profiles/author-profiles.js
+++ b/blocks/author-profiles/author-profiles.js
@@ -7,23 +7,29 @@ async function getAuthorEntries(keys) {
   const entryFilter = ((entry) => (keys.includes(entry.path)));
   const unsortedEntries = await ffetch('/authors-index.json').filter(entryFilter).limit(keys.length).all();
   const sortedEntries = [];
-  keys.forEach((key) => {
-    sortedEntries.push(completeEntry(unsortedEntries.find((entry) => (key === entry.path))));
-  });
+  if (unsortedEntries) {
+    keys.forEach((key) => {
+      sortedEntries.push(completeEntry(unsortedEntries.find((entry) => (key === entry.path))));
+    });
+  }
   return sortedEntries;
 }
 
 async function addAuthorProfiles(block, keys) {
   const entries = await getAuthorEntries(keys);
-  if (keys.length > 1) {
-    block.classList.add(`elems${keys.length}`);
-    entries.forEach((entry) => {
-      const profile = div({ class: 'author-profile hor' }, renderProfile(entry));
-      block.append(profile);
-    });
+  if (entries && entries.length) {
+    if (keys.length > 1) {
+      block.classList.add(`elems${keys.length}`);
+      entries.forEach((entry) => {
+        const profile = div({ class: 'author-profile hor' }, renderProfile(entry));
+        block.append(profile);
+      });
+    } else {
+      block.classList.add('vertical');
+      block.append(div({ class: 'author-profile' }, renderProfile(entries[0])));
+    }
   } else {
-    block.classList.add('vertical');
-    block.append(div({ class: 'author-profile' }, renderProfile(entries[0])));
+    block.parentNode.remove();
   }
 }
 


### PR DESCRIPTION
fix: removed fallback role 'Author'
fix: handle empty results: if no entries are returned, don't render anything, both for single author profiles and for author profile lists. Also remove the parent node to ensure it does not take up vertical space

Fix #239

Test URLs for case 1 (remove default role):
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/12/sap-maxattention-serving-cios-business-transformation
- After: https://239-author-profile-issues--hlx-test--urfuwo.hlx.live/blog/2023/12/sap-maxattention-serving-cios-business-transformation

Test URLs for case 2 (don't render anything if no author profiles have been found):
- Before: https://main--hlx-test--urfuwo.hlx.page/blog/2023/04/planalytics-weather-analytics-reduce-food-waste
- After: https://239-author-profile-issues--hlx-test--urfuwo.hlx.live/blog/2023/04/planalytics-weather-analytics-reduce-food-waste