### PR TITLE
L1 - flexible height hero with full background image, docks to next element

### DIFF
--- a/aemedge/blocks/hero/hero.css
+++ b/aemedge/blocks/hero/hero.css
@@ -240,6 +240,10 @@ udex-hero-banner .custom-background-image:dir(rtl) {
   background-color: var(--udexColorTeal2);
 }
 
+.hero-wrapper.hero-text-white-wrapper {
+  color: var(--udexColorNeutralWhite);
+}
+
 udex-hero-banner .text-black-wrapper,
 udex-hero-banner .text-neutral-black {
   color: var(--udexColorNeutralBlack);
@@ -253,4 +257,12 @@ udex-hero-banner .text-neutral-black {
   .hero-wrapper.fixed-height-small-style-wrapper udex-hero-banner {
     --udexHeroBannerMinHeight: 450px;
   }
+}
+
+.hero-wrapper.full-background-image-style-wrapper udex-hero-banner {
+  --udexHeroBannerBackgroundImageObjectFit: cover;
+}
+
+.hero-container:has(.hero-dock-to-next-wrapper) {
+  padding-bottom: 0;
 }

--- a/aemedge/blocks/hero/hero.css
+++ b/aemedge/blocks/hero/hero.css
@@ -15,7 +15,7 @@ udex-hero-banner .hero-banner p {
 udex-hero-banner {
   container-type: inline-size;
   container-name: hero-wrapper;
-  display: inline-block;
+  display: block;
   width: 100%;
 }
 


### PR DESCRIPTION
Motivation:
- Implement the hero as needed at the top of L1 pages
- Figma ref: https://www.figma.com/file/oSetT4LbatRmXlcB2A7V8Z/Content-Hubs-2024?type=design&node-id=4075-169235&mode=design&t=A7ULffWUtHmo32sM-4

Two features were implemented:
- flexible height hero with a background image that covers the entire hero
- hero can be configured to dock to next element, i.e., not have vertical spacing to the next element

Fix #156 
Fix #288 

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.page/draft/hupe/l1/156-fixed-hero-full-background
- After: https://156-hero-flex-height--hlx-test--urfuwo.hlx.live/draft/hupe/l1/156-fixed-hero-full-background

- [X] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
hero (full background image)  | [doc-link](https://sap.sharepoint.com/:w:/r/sites/207899/Shared%20Documents/website/tools/sidekick/blocks/hero.docx?d=w0b62f23a5c8f4c2dba2ec444d3631b51&csf=1&web=1&e=LHGiEQ)
hero (dock to next)  | [doc-link](https://sap.sharepoint.com/:w:/r/sites/207899/Shared%20Documents/website/tools/sidekick/blocks/hero.docx?d=w0b62f23a5c8f4c2dba2ec444d3631b51&csf=1&web=1&e=LHGiEQ)

Related to https://github.com/urfuwo/hlx-test/pull/296 (which adds padding to the element below it on the L1 page)