### PR TITLE
L1 - Column section: top and bottom padding

### DIFF
--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -276,7 +276,6 @@ main .section.column-section {
   main .section.column-section {
     display: grid;
     grid-auto-flow: row dense;
-
     padding-top: var(--udexSpacer64);
     padding-bottom: var(--udexSpacer48);
     column-gap: var(--udexGridGutters);

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -268,10 +268,17 @@ main .section {
   display: none;
 }
 
+main .section.column-section {
+  padding-top: var(--udexSpacer56);
+  padding-bottom: var(--udexSpacer40);
+}
+
 @media (width >=980px) {
-  .column-section {
+  main .section.column-section {
     display: grid;
     grid-auto-flow: row dense;
+    padding-top: var(--udexSpacer64);
+    padding-bottom: var(--udexSpacer48);
   }
 
   .column-section-block {
@@ -339,5 +346,12 @@ main .section {
 
   .column-section > div.column-section-block > div:first-child > div:first-child > div:first-child > div:first-child > *:first-child {
     margin-top: 0;
+  }
+}
+
+@media (width >=1280px) {
+  main .section.column-section {
+    padding-top: var(--udexSpacer84);
+    padding-bottom: var(--udexSpacer56);
   }
 }


### PR DESCRIPTION
Motivation: Add top and bottom padding to the column section element (directly beneath the top hero) on the L1 page
Figma ref: https://www.figma.com/file/oSetT4LbatRmXlcB2A7V8Z/Content-Hubs-2024?type=design&node-id=4075-169233&mode=design&t=H9W7a6YSqBaqEf8q-4

Set top and bottom padding of column section, according to https://www.figma.com/file/oSetT4LbatRmXlcB2A7V8Z/Content-Hubs-2024?type=design&node-id=4075-169233&mode=design&t=H9W7a6YSqBaqEf8q-4:

XS-S: top: 56, bottom: 40
M: top: 64, bottom: 48
L-XL: top: 84, bottom: 56

Fix #289

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/draft/hupe/l1/289-column-section
- After: https://289-l1-column-section-block-needs-top-spacing--hlx-test--urfuwo.hlx.live/draft/hupe/l1/289-column-section

Note: the template page does not use the L1 template (as the PR is not yet merged), but that is not important

Related to https://github.com/urfuwo/hlx-test/pull/294 (which styles the hero above it)