### PR TITLE
Align hero content with rest of the page

### DIFF
--- a/aemedge/blocks/hero/hero.css
+++ b/aemedge/blocks/hero/hero.css
@@ -95,7 +95,7 @@ udex-hero-banner .hero-banner .media-blend__intro-text {
 }
 
 udex-hero-banner .hero-banner.media-blend__content {
-  margin-left: calc(var(--udexGridMargins) - 22px);
+  margin-left: calc(var(--hero-margin) - 22px);
 }
 
 udex-hero-banner .hero-banner .media-blend__content ui5-rating-indicator {
@@ -151,7 +151,7 @@ udex-hero-banner .hero-banner .media-blend__buttons udex-button:first-of-type {
 udex-hero-banner .hero-banner.media-blend__additional-content {
   display: flex;
   align-items: center;
-  margin-right: calc(var(--udexGridMargins) - var(--udexSpacer8));
+  margin-right: calc(var(--hero-margin) - var(--udexSpacer8));
 }
 
 udex-hero-banner .custom-background-image {

--- a/aemedge/blocks/hero/hero.css
+++ b/aemedge/blocks/hero/hero.css
@@ -95,7 +95,7 @@ udex-hero-banner .hero-banner .media-blend__intro-text {
 }
 
 udex-hero-banner .hero-banner.media-blend__content {
-  margin-left: calc(var(--udexGridMargins) - var(--udexSpacer16));
+  margin-left: calc(var(--udexGridMargins) - 22px);
 }
 
 udex-hero-banner .hero-banner .media-blend__content ui5-rating-indicator {

--- a/aemedge/blocks/hero/hero.css
+++ b/aemedge/blocks/hero/hero.css
@@ -94,6 +94,10 @@ udex-hero-banner .hero-banner .media-blend__intro-text {
   color: var(--udexColorGrey6, #5b738b);
 }
 
+udex-hero-banner .hero-banner.media-blend__content {
+  margin-left: calc(var(--udexGridMargins) - var(--udexSpacer16));
+}
+
 udex-hero-banner .hero-banner .media-blend__content ui5-rating-indicator {
   margin: 0;
 }
@@ -121,7 +125,10 @@ udex-hero-banner .hero-banner .media-blend__info-block span:first-of-type {
   margin-left: 10px;
 }
 
-udex-hero-banner .hero-banner .media-blend__info-block span:last-of-type::after {
+udex-hero-banner
+  .hero-banner
+  .media-blend__info-block
+  span:last-of-type::after {
   margin: 0;
   content: '';
 }
@@ -141,9 +148,10 @@ udex-hero-banner .hero-banner .media-blend__buttons udex-button:first-of-type {
   }
 }
 
-udex-hero-banner .hero-banner .media-blend__additional-content {
+udex-hero-banner .hero-banner.media-blend__additional-content {
   display: flex;
   align-items: center;
+  margin-right: calc(var(--udexGridMargins) - var(--udexSpacer8));
 }
 
 udex-hero-banner .custom-background-image {
@@ -151,7 +159,10 @@ udex-hero-banner .custom-background-image {
   width: 100%;
   height: 100%;
   object-fit: var(--udexHeroBannerBackgroundImageObjectFit, contain);
-  object-position: var(--udexHeroBannerVerticalLayoutBackgroundImageAlignment, bottom right);
+  object-position: var(
+    --udexHeroBannerVerticalLayoutBackgroundImageAlignment,
+    bottom right
+  );
   z-index: var(--udexHeroBannerBackroundImageZIndex, 1);
 }
 

--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -50,7 +50,9 @@
   --text-color: var(--sapShell_TextColor);
   --udexGridGutters: var(--udexGridXSGutters);
   --udexGridMargins: var(--udexGridXSMargins);
-  --sapFontFamily: "72 Brand Variable", "72 Brand Variable Fallback", "Arial", "Helvetica", "sans-serif";
+  --sapFontFamily: '72 Brand Variable', '72 Brand Variable Fallback', 'Arial',
+    'Helvetica', 'sans-serif';
+  --hero-margin: var(--udexGridMargins);
 }
 
 /* S */
@@ -82,6 +84,7 @@
   :root {
     --udexGridGutters: var(--udexGridXLGutters);
     --udexGridMargins: var(--udexGridXLMargins);
+    --hero-margin: 246px;
   }
 }
 
@@ -286,7 +289,7 @@ main .section.column-section {
     overflow-x: hidden;
   }
 
-  .column-section>div:not(.column-section-block) {
+  .column-section > div:not(.column-section-block) {
     display: none;
   }
 
@@ -318,21 +321,21 @@ main .section.column-section {
     grid-template-columns: 1fr 3fr;
   }
 
-  .column-section>div.column-section-left-block {
+  .column-section > div.column-section-left-block {
     margin-right: 16px;
     grid-column: 1;
   }
 
-  .column-section>div.column-section-right-block {
+  .column-section > div.column-section-right-block {
     margin-left: 16px;
     grid-column: 2;
   }
 
-  .column-section>div.column-section-block>*:first-child {
+  .column-section > div.column-section-block > *:first-child {
     margin-top: 0;
   }
 
-  .column-section>div.column-section-block>div:first-child>*:first-child {
+  .column-section > div.column-section-block > div:first-child > *:first-child {
     margin-top: 0;
   }
 

--- a/aemedge/templates/hub/hub.css
+++ b/aemedge/templates/hub/hub.css
@@ -87,6 +87,8 @@
   }
 
   &:has(aside) {
+    --hero-margin: 0;
+
     grid-template:
       'header header' 60px
       'side-nav main-content' auto


### PR DESCRIPTION
Hacky way to restrict hero content. Ideally it must be done by slot variables but they do not expose padding/margins on all axis. 

Fix #220 

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/draft/mhaack/hero-demo
- After: https://220-restrict-hero-content--hlx-test--urfuwo.hlx.live/draft/mhaack/hero-demo