### PR TITLE
L2 enforce sidenav

### DIFF
--- a/aemedge/templates/hub/hub.css
+++ b/aemedge/templates/hub/hub.css
@@ -68,41 +68,21 @@
 }
 
 .hub-l2.appear {
+  --hero-margin: 0;
+
   grid-template:
-    'header' 60px
-    'main-content' auto
-    'footer' auto
-    / 1fr;
+    'header header' 60px
+    'side-nav main-content' auto
+    'footer footer' auto
+    / min-content 1fr;
 
   & > main {
     @media (width >= 980px) {
       & > :not(.hero-container, .title-banner-container) {
-        padding-inline: var(--udexGridMargins);
+        padding-inline: var(--udexGridGutters) var(--udexGridMargins);
 
         & > * {
           margin: unset;
-        }
-      }
-    }
-  }
-
-  &:has(aside) {
-    --hero-margin: 0;
-
-    grid-template:
-      'header header' 60px
-      'side-nav main-content' auto
-      'footer footer' auto
-      / min-content 1fr;
-
-    & > main {
-      @media (width >= 980px) {
-        & > :not(.hero-container, .title-banner-container) {
-          padding-inline: var(--udexGridGutters) var(--udexGridMargins);
-
-          & > * {
-            margin: unset;
-          }
         }
       }
     }

--- a/aemedge/templates/hub/hub.js
+++ b/aemedge/templates/hub/hub.js
@@ -6,8 +6,7 @@ function decorate(doc) {
   const main = doc.querySelector('main');
   containerize(main, '.hero');
   const template = getMetadata('template');
-  const showSideNav = getMetadata('sidenav') !== 'false';
-  if (template === 'hub-l2' && showSideNav) main.parentNode.insertBefore(aside(), main);
+  if (template === 'hub-l2') main.parentNode.insertBefore(aside(), main);
 }
 
 decorate(document);


### PR DESCRIPTION
Do not allow author, topic, tag pages (L2 pages in general) to drop the sidenav
Implication: make the space for a sidenav, even if the sidenav can be found (= white space on the left)

Fix #304

Test URL author:
- Before: https://main--hlx-test--urfuwo.hlx.page/author/scottrussell
- After: https://304-l2-enforce-sidenav--hlx-test--urfuwo.hlx.live/author/scottrussell

Test URL topics:
- Before: https://main--hlx-test--urfuwo.hlx.page/topics/cloud
- After: https://304-l2-enforce-sidenav--hlx-test--urfuwo.hlx.live/topics/cloud

Test URL author:
- Before: https://main--hlx-test--urfuwo.hlx.page/tags/customer-story
- After: https://304-l2-enforce-sidenav--hlx-test--urfuwo.hlx.live/tags/customer-story
