### PR TITLE
Footer changes (Social icons and more)

### DIFF
--- a/aemedge/blocks/contact/contact.css
+++ b/aemedge/blocks/contact/contact.css
@@ -55,6 +55,11 @@
   padding-right: var(--udexSpacer16);
 }
 
+.block.contact .icon img {
+  height: 1.125rem;
+  width: 1.125rem;
+}
+
 /* S */
 @media (width >=640px) {
   .block.contact {

--- a/aemedge/blocks/contact/contact.js
+++ b/aemedge/blocks/contact/contact.js
@@ -11,7 +11,6 @@ export default async function decorate(block) {
       select(
         { 'aria-label': 'Country Selector' },
         option({ value: 'us' }, 'United States - English'),
-        option({ value: 'cn' }, '中文 - Chinese'),
       ),
     ),
   );

--- a/aemedge/blocks/footer/footer.css
+++ b/aemedge/blocks/footer/footer.css
@@ -28,6 +28,23 @@
   padding-top: var(--udexSpacer40);
 }
 
+.block.footer a {
+  color: var(--text-color);
+  text-decoration: none;
+}
+
+.block.footer a:hover {
+  color: var(--sapLink_Hover_Color);
+}
+
+footer .block.link-group p {
+  margin: 0;
+}
+
+footer .block.link-group p strong {
+  font-weight: var(--udexTypographyFontWeightMedium);
+}
+
 /* S */
 @media (width >= 640px) {
   .block.footer > div {
@@ -45,6 +62,9 @@
     padding-top: 0;
   }
 
+  .block.footer .block.link-group > div:first-of-type > div {
+    padding-bottom: 11.5px;
+  }
 }
 
 /* L */
@@ -56,5 +76,4 @@
   .block.footer .icon-back-to-top {
     padding-top: 0;
   }
-
 }

--- a/aemedge/blocks/social/social.css
+++ b/aemedge/blocks/social/social.css
@@ -19,6 +19,10 @@
   margin: 6px;
 }
 
+.block.social > div:first-of-type > div {
+  margin-left: 0;
+}
+
 .block.social .icon {
   display: flex;
   width: 16px;


### PR DESCRIPTION
fix: removed chinese from country selector
fix: L, XL: aligned footer columns at the top with the brand logo and country selector
fix: social media: use single-line table variant
fix: contact: use 18px / 1.125rem icons as specified
fix: links: use black, no underline, same hover color as sidenav
fix: link group headline: adapted font weight (was too bold)
fix: align social icons with rest of contact block on the left
Ref: https://sap.frontify.com/document/223143#/-/footer/usage

Fix #320 

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/author/juliawhite
- After: https://320-social-icons-in-footer--hlx-test--urfuwo.hlx.live/author/juliawhite
