### PR TITLE
Replace title-banner with hero - part I

### DIFF
--- a/aemedge/blocks/hero/hero.js
+++ b/aemedge/blocks/hero/hero.js
@@ -1,6 +1,6 @@
 import '@udex/webcomponents/dist/HeroBanner.js';
 import { div, span, p } from '../../scripts/dom-builder.js';
-import { getMetadata } from '../../scripts/aem.js';
+import { fetchPlaceholders, getMetadata, toCamelCase } from '../../scripts/aem.js';
 import { formatDate } from '../../scripts/utils.js';
 
 function calculateInitials(name) {
@@ -45,6 +45,17 @@ function decorateMetaInfo() {
   return infoBlockWrapper;
 }
 
+async function replacePlaceholderText(elem) {
+  if (elem && (elem.innerText.includes('[page]') || elem.innerText.includes('[author]'))) {
+    const ph = await fetchPlaceholders();
+    const adaptedPath = toCamelCase(window.location.pathname
+      .replace('tags', 'tag').replace('topics', 'topic').substring(1));
+    elem.innerHTML = elem.innerHTML.replace('[page]', ph[adaptedPath] ? ph[adaptedPath] : '');
+    elem.innerHTML = elem.innerHTML.replace('[author]', getMetadata('author') || '');
+  }
+  return elem;
+}
+
 /**
  * loads and decorates the footer
  * @param {Element} block The footer block element
@@ -60,7 +71,7 @@ export default async function decorate(block) {
       class: ['hero-banner', 'media-blend__content'],
     },
     intro ? p({ class: 'media-blend__intro-text' }, block.querySelector('h6')?.textContent) : '',
-    heading,
+    await replacePlaceholderText(heading),
   );
   hero.append(contentSlot);
 


### PR DESCRIPTION
fix: replace title-banner with hero, part one: Enable hero to handle text placeholders [author] <= metadata('author'), [page] <= adapted path mapped by placeholders

Q: What is part two?
A: Removing title-banner block from the codebase (which can only be done after all pages have been adapted to the hero)

Fix #279

Test URL 1 (Topic page with placeholder text [page] in the hero):
- Before: https://main--hlx-test--urfuwo.hlx.live/draft/hupe/279-topic-template
- After: https://279-author-topic-tag-page-cleanup--hlx-test--urfuwo.hlx.live/draft/hupe/279-topic-template

Test URL 2 (Tag page with placeholder text [page] in the hero):
- Before: https://main--hlx-test--urfuwo.hlx.live/draft/hupe/279-tag-template
- After: https://279-author-topic-tag-page-cleanup--hlx-test--urfuwo.hlx.live/draft/hupe/279-tag-template

Test URL 3 (Author page with placeholder text [author] in the hero):
- Before: https://main--hlx-test--urfuwo.hlx.live/draft/hupe/279-author-template
- After: https://279-author-topic-tag-page-cleanup--hlx-test--urfuwo.hlx.live/draft/hupe/279-author-template