### PR TITLE
Spacing changed for h2 and h3

### DIFF
--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -164,6 +164,14 @@ blockquote {
   margin-bottom: 1em;
 }
 
+:is(h2, h3) + p {
+  margin-block: 0 40px;
+}
+
+:is(h2, h3):not(:has(+ p)) {
+  margin-block-end: 40px;
+}
+
 /* missing styles, assumption */
 code {
   padding: 0.125em;


### PR DESCRIPTION
Spacing only applied for H2 & H3

Fix #326 

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/topics/
- After: https://326-headling-spacing--hlx-test--urfuwo.hlx.live/topics/
