### PR TITLE
chore: fixing section spacing for all templates

### DIFF
--- a/aemedge/styles/styles.css
+++ b/aemedge/styles/styles.css
@@ -269,10 +269,6 @@ main img {
   width: 100%;
 }
 
-/* sections: 56px spacing at the bottom */
-main .section {
-  padding-bottom: 56px;
-}
 
 /**
  * Styles for embedding video content.

--- a/aemedge/templates/article/article.css
+++ b/aemedge/templates/article/article.css
@@ -44,6 +44,7 @@ main {
       ) {
       grid-column: 1 / 2;
       margin-inline-start: var(--udexGridMargins);
+      padding-block-end: 56px;
     }
 
     & > [data-location='sidebar'] {
@@ -55,6 +56,7 @@ main {
     & > [data-location='document-footer'] {
       grid-column: -3 / span 2;
       margin-inline: var(--udexGridMargins);
+      padding-block-end: 84px;
     }
 
     /* if page has table of contents it has a 3 column layout */

--- a/aemedge/templates/hub/hub.css
+++ b/aemedge/templates/hub/hub.css
@@ -41,6 +41,14 @@
         margin: 0 var(--udexGridMargins);
       }
     }
+
+    & > :not(:last-child, .hero-container) {
+      padding-block-end: 56px;
+    }
+
+    & > :last-child {
+      padding-block-end: 84px;
+    }
   }
 
   & > footer {
@@ -76,6 +84,10 @@
 
   & > main {
     @media (width >= 980px) {
+      & .hero-container {
+        margin-block-end: 84px;
+      }
+
       & > :not(.hero-container, .title-banner-container) {
         padding-inline: var(--udexGridMargins);
 


### PR DESCRIPTION
Instead of default padding at bottom of 56px for all sections it is required that first section gets 84px top padding, middle sections with 56px bottom padding and last section gets 84px padding at bottom. This is inline with figma design. 

Test URLs:

L3
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
- After: https://fix-spacing--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications

L2
- Before: https://main--hlx-test--urfuwo.hlx.live/author/jacquelineprause
- After: https://fix-spacing--hlx-test--urfuwo.hlx.live/author/jacquelineprause

L1
- Before: https://main--hlx-test--urfuwo.hlx.live/topics/
- After: https://fix-spacing--hlx-test--urfuwo.hlx.live/topics/
