### PR TITLE
346: Hero in XS + S: Text bleeds into side image

### DIFF
--- a/aemedge/blocks/hero/hero.css
+++ b/aemedge/blocks/hero/hero.css
@@ -155,6 +155,7 @@ udex-hero-banner .hero-banner.media-blend__additional-content {
 }
 
 udex-hero-banner .custom-background-image {
+  display: none;
   position: absolute;
   width: 100%;
   height: 100%;
@@ -168,6 +169,12 @@ udex-hero-banner .custom-background-image {
 
 udex-hero-banner .custom-background-image:dir(rtl) {
   transform: scaleX(-1);
+}
+
+@container hero-wrapper (width >= 640px) {
+  udex-hero-banner .custom-background-image {
+    display: block
+  }
 }
 
 .hero-wrapper.hero-background-blue-wrapper,
@@ -272,6 +279,10 @@ udex-hero-banner .text-neutral-black {
 
 .hero-wrapper.full-background-image-style-wrapper udex-hero-banner {
   --udexHeroBannerBackgroundImageObjectFit: cover;
+
+  .custom-background-image {
+    display: block
+  }
 }
 
 .hero-container:has(.hero-no-bottom-space-wrapper) {


### PR DESCRIPTION
Fix #346 

Test URLs:

L2 (unchanged)
- Before: https://main--hlx-test--urfuwo.hlx.page/draft/skhare/content-list-test
- After: https://346-xs-s-hero-text-bleeds-into-side-image--hlx-test--urfuwo.hlx.page/draft/skhare/content-list-test

L2, media blend
- Before: https://main--hlx-test--urfuwo.hlx.live/author/juliawhite
- After: https://346-xs-s-hero-text-bleeds-into-side-image--hlx-test--urfuwo.hlx.live/author/juliawhite

L1 (unchanged)
- Before: https://main--hlx-test--urfuwo.hlx.live/draft/skhare/l1-sample-page
- After: https://346-xs-s-hero-text-bleeds-into-side-image--hlx-test--urfuwo.hlx.live/draft/skhare/l1-sample-page

Article page (unchanged)
- Before: https://main--hlx-test--urfuwo.hlx.page/news/2024/01/accelerate-innovation-with-clean-core-strategy
- After: https://346-xs-s-hero-text-bleeds-into-side-image--hlx-test--urfuwo.hlx.page/news/2024/01/accelerate-innovation-with-clean-core-strategy
