### PR TITLE
102: Analytics and Tracking MVP for News

### DIFF
--- a/aemedge/scripts/delayed.js
+++ b/aemedge/scripts/delayed.js
@@ -1,7 +1,39 @@
 // eslint-disable-next-line import/no-cycle
-import { sampleRUM } from './aem.js';
+import { loadScript, sampleRUM } from './aem.js';
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
 // add more delayed functionality here
+
+function getEnvType(hostname = window.location.hostname) {
+  const fqdnToEnvType = {
+    'www.sap.com': 'prod',
+    'www-qa.sap.com': 'stage',
+    'main--hlx-test--urfuwo.hlx.live': 'stage',
+  };
+  return fqdnToEnvType[hostname] || 'dev';
+}
+
+async function sendBeacon(stl = null) {
+  window.adobeDataLayer.push({
+    event: stl ? 'stlBeaconReady' : 'stBeaconReady',
+  });
+}
+
+async function loadAdobeDC() {
+  const adobeTagsSrc = {
+    dev: 'https://assets.adobedtm.com/ccc66c06b30b/6fa889b263e0/launch-3318725e3375-development.min.js',
+    stage: 'https://assets.adobedtm.com/ccc66c06b30b/6fa889b263e0/launch-6615f1bb001d-staging.min.js',
+    prod: 'https://assets.adobedtm.com/ccc66c06b30b/6fa889b263e0/launch-69ede165613b.min.js',
+  };
+  const envType = getEnvType();
+  if (envType && adobeTagsSrc[envType]) {
+    if (envType !== 'dev' || ((new URLSearchParams(window.location.search)).get('tr')) != null) {
+      await loadScript(adobeTagsSrc[envType], {});
+      await sendBeacon();
+    }
+  }
+}
+
+await loadAdobeDC();

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -355,4 +355,37 @@ async function loadPage() {
   loadDelayed();
 }
 
+async function initDataLayer() {
+  window.adobeDataLayer = [];
+  window.adobeDataLayer.push({
+    event: 'globalDL',
+    site: {
+      country: 'glo',
+      name: 'www',
+    },
+    user: {
+      type: 'visitor',
+      loginStatus: 'no',
+    },
+  });
+  const relpath = window.location.pathname.substring(1);
+  window.adobeDataLayer.push({
+    event: 'pageView',
+    page: {
+      country: 'glo',
+      language: 'en',
+      name: window.location.pathname,
+      section: relpath.indexOf('/') > 0 ? relpath.substring(0, relpath.indexOf('/')) : relpath,
+      url: window.location.href,
+      referrer: document.referrer,
+      title: document.querySelector('title').textContent.replace(/[\n\t]/gm, ''),
+    },
+    user: {
+      type: 'visitor',
+      loginStatus: 'no',
+    },
+  });
+}
+
+initDataLayer();
 loadPage();


### PR DESCRIPTION
feat: Tracking and Analytics (Adobe Data Collection)
- SAP MVP native data layer implemented
- Launch SAP MVP (News) loaded and beacon fired on PROD (www.sap.com) and QA (main...hlx.live, www-qa.sap.com)
- Disabled on DEV (localhost, ...hlx.page), unless query param 'tr' is specified

Notes:
- To inspect the data layer, use adobeDataLayer.getState() in console
- The term 'AdobeDC' (Adobe Data Collection) and param name 'tr' have been used as users are sensitive to tracking. 'AdobeTags' has been used instead of AdobeLaunch, as it is the product name
- Currently, loading Tags/Launch will cause a lot of errors in the console log (will be addressed on the Analytics side)

Fix #102 

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/12/being-human-in-the-age-of-ai
- After: https://102-analytics-news--hlx-test--urfuwo.hlx.live/blog/2023/12/being-human-in-the-age-of-ai

How to see it in action:
- In an anonymous browser, open https://102-analytics-news--hlx-test--urfuwo.hlx.live/blog/2023/12/being-human-in-the-age-of-ai, append parameter ?tr, request and wait
Expected results:
- The cookie consent manager should pop up
- A lot of console errors will manifest in the console (misconfiguration on Analytics side)
- When inspecting window.adobeDataLayer.getState(), you should see a data layer structure with 3 sections: site, user, page
