### PR TITLE
292 - Hero show avatar image

### DIFF
--- a/aemedge/blocks/author-profile/author-profile.js
+++ b/aemedge/blocks/author-profile/author-profile.js
@@ -1,12 +1,11 @@
-import { getMetadata } from '../../scripts/aem.js';
 import { addAuthorProfiles } from '../author-profiles/author-profiles.js';
+import { getAuthorNames } from '../../scripts/article.js';
 
 export default async function decorate(block) {
-  const authorList = getMetadata('author');
-  const keys = authorList ? authorList.split(',').map((e) => e.trim()) : [authorList];
+  const keys = getAuthorNames();
   if (keys && keys.length > 0) {
     block.classList.add('author-profiles');
     block.classList.remove('author-profile');
-    addAuthorProfiles(block, keys);
+    await addAuthorProfiles(block, keys);
   }
 }

--- a/aemedge/blocks/hero/hero.js
+++ b/aemedge/blocks/hero/hero.js
@@ -7,7 +7,8 @@ import {
 } from '../../scripts/aem.js';
 import { formatDate } from '../../scripts/utils.js';
 import Tag from '../../libs/tag/tag.js';
-import { buildAuthorUrl, removeAuthorsSuffixes } from '../../scripts/article.js';
+import { buildAuthorUrl, getAuthorEntries, getAuthorNames } from '../../scripts/article.js';
+import Avatar from '../../libs/avatar/avatar.js';
 
 function calculateInitials(name) {
   const nameParts = name.split(' ');
@@ -22,24 +23,32 @@ function buildAuthorEl(author) {
   return a({ class: 'media-blend__author', href: buildAuthorUrl(author) }, author);
 }
 
+function addAuthorAvatarImg(authorName, avatar) {
+  return getAuthorEntries([authorName]).then((authorEntries) => {
+    if (authorEntries && authorEntries.length > 0) {
+      const ae = authorEntries[0];
+      const picture = new Avatar(ae.title, ae.description, ae.path, ae.image).getImage();
+      avatar.append(picture.querySelector('img')); /* default slot */
+    }
+  });
+}
+
 function decorateMetaInfo() {
   const infoBlockWrapper = span({ class: 'media-blend__info-block' });
 
-  const authors = removeAuthorsSuffixes(getMetadata('author'))
-    .split(',')
-    .map((author) => author.trim());
+  const authorNames = getAuthorNames();
   const authorEl = span({ class: 'media-blend__authors' });
-  if (authors.length > 0) {
-    if (authors.length === 1 && !!authors[0]) {
+  if (authorNames.length > 0) {
+    if (authorNames.length === 1 && !!authorNames[0]) {
       const avatar = document.createElement('udex-avatar');
       avatar.setAttribute('size', 'XS');
-      avatar.setAttribute('initials', calculateInitials(authors[0]));
+      avatar.setAttribute('initials', calculateInitials(authorNames[0]));
       avatar.setAttribute('color-scheme', 'Neutral');
-
+      addAuthorAvatarImg(authorNames[0], avatar);
       infoBlockWrapper.append(avatar);
-      authorEl.append(buildAuthorEl(authors[0]));
+      authorEl.append(buildAuthorEl(authorNames[0]));
     } else {
-      authors.forEach((author) => {
+      authorNames.forEach((author) => {
         if (author) {
           authorEl.append(buildAuthorEl(author));
         }

--- a/aemedge/libs/avatar/avatar.js
+++ b/aemedge/libs/avatar/avatar.js
@@ -13,7 +13,7 @@ export default class Avatar {
     this.image = image;
   }
 
-  getOptimizedPicture() {
+  getImage() {
     return this.image ? createOptimizedPicture(this.image, this.title, false, breakpoints) : null;
   }
 
@@ -23,7 +23,7 @@ export default class Avatar {
     }
     const element = div(
       { class: 'avatar-wrapper' },
-      div({ class: `avatar ${size}` }, this.image ? div(this.getOptimizedPicture()) : div()),
+      div({ class: `avatar ${size}` }, this.image ? div(this.getImage()) : div()),
       div(
         { class: 'avatar-info' },
         div({ class: 'title' }, a({ href: this.path }, div(`${this.title}`))),
@@ -39,7 +39,7 @@ export default class Avatar {
     }
     const element = div(
       { class: 'avatar-wrapper' },
-      div({ class: `avatar ${size}` }, this.image ? div(this.getOptimizedPicture()) : div()),
+      div({ class: `avatar ${size}` }, this.image ? div(this.getImage()) : div()),
       div(
         { class: 'avatar-details' },
         h2(this.title),

--- a/aemedge/scripts/article.js
+++ b/aemedge/scripts/article.js
@@ -1,4 +1,4 @@
-import { toClassName } from './aem.js';
+import { getMetadata, toClassName } from './aem.js';
 import ffetch from './ffetch.js';
 
 function completeEntry(entry) {
@@ -69,10 +69,15 @@ function removeAuthorsSuffixes(authors, suffixes = defaultSuffixes) {
   return authorsWithoutSuffixes;
 }
 
+function getAuthorNames() {
+  return removeAuthorsSuffixes(getMetadata('author')).split(',').map((e) => e.trim());
+}
+
 export {
   allAuthorEntries,
   authorEntry,
   getAuthorEntries,
   buildAuthorUrl,
   removeAuthorsSuffixes,
+  getAuthorNames,
 };


### PR DESCRIPTION
fix: add avatar image to hero if available and the number of authors is one

Limitations: The image is not (necessarily) shown as round, which needs to be addressed with the UDex Avatar component team

Fix #292 

Test URL (single author with avatar image):
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/12/being-human-in-the-age-of-ai
- After: https://292-hero-avatar-display-author-picture--hlx-test--urfuwo.hlx.live/blog/2023/12/being-human-in-the-age-of-ai

Test URL (multiple authors, no avatar image shown, unchanged):
- Before: https://main--hlx-test--urfuwo.hlx.live/draft/hupe/224-multiple-authors
- After: https://292-hero-avatar-display-author-picture--hlx-test--urfuwo.hlx.live/draft/hupe/224-multiple-authors

Test URL (no avatar available, unchanged):
- Before: https://main--hlx-test--urfuwo.hlx.page/news/2024/03/sap-and-nvidia-to-accelerate-generative-ai-adoption
- After: https://292-hero-avatar-display-author-picture--hlx-test--urfuwo.hlx.live/news/2024/03/sap-and-nvidia-to-accelerate-generative-ai-adoption