### PR TITLE
Change site name to 'sap' in data layer

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -361,7 +361,7 @@ async function initDataLayer() {
     event: 'globalDL',
     site: {
       country: 'glo',
-      name: 'www',
+      name: 'sap',
     },
     user: {
       type: 'visitor',


### PR DESCRIPTION
fix: site name in data layer is 'sap', not 'www'

Fix #418

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/
- After: https://418-analytics-dl-site-name--hlx-test--urfuwo.hlx.live/blog/ => append query param "?tr" to URL and reload page (to enable tracking on this domain) => browser console: adobeDataLayer.getState() > inspect: site > name must be 'sap'
