### PR TITLE
410 - author profiles - fix author name vs title mixup

### DIFF
--- a/aemedge/blocks/author-profiles/author-profiles.js
+++ b/aemedge/blocks/author-profiles/author-profiles.js
@@ -8,14 +8,15 @@ async function addAuthorProfiles(block, keys) {
   if (entries && entries.length) {
     if (keys.length > 1) {
       block.classList.add(`elems${keys.length}`);
-      entries.forEach((entry) => {
-        const avatar = new Avatar(entry.title, entry.description, entry.path, entry.image);
+      entries.forEach((e) => {
+        const avatar = new Avatar(e.author, e.title, e.description, e.path, e.image);
         const profile = div({ class: 'author-profile hor' }, avatar.renderDetails('big'));
         block.append(profile);
       });
     } else {
       block.classList.add('vertical');
       const avatar = new Avatar(
+        entries[0].author,
         entries[0].title,
         entries[0].description,
         entries[0].path,

--- a/aemedge/blocks/hero/hero.js
+++ b/aemedge/blocks/hero/hero.js
@@ -27,7 +27,7 @@ function addAuthorAvatarImg(authorName, avatar) {
   return getAuthorEntries([authorName]).then((authorEntries) => {
     if (authorEntries && authorEntries.length > 0) {
       const ae = authorEntries[0];
-      const picture = new Avatar(ae.title, ae.description, ae.path, ae.image).getImage();
+      const picture = new Avatar(ae.author, ae.title, ae.description, ae.path, ae.image).getImage();
       avatar.append(picture.querySelector('img')); /* default slot */
     }
   });

--- a/aemedge/libs/avatar/avatar.css
+++ b/aemedge/libs/avatar/avatar.css
@@ -55,7 +55,7 @@
   flex-direction: column;
   justify-content: center;
 
-  & .title {
+  & .name {
     & a {
       font-size: var(--udexTypographyBodyXSFontSize);
       font-weight: var(--udexTypographyFontWeightMedium);

--- a/aemedge/libs/avatar/avatar.js
+++ b/aemedge/libs/avatar/avatar.js
@@ -6,7 +6,8 @@ import {
 const breakpoints = [{ width: '480' }];
 
 export default class Avatar {
-  constructor(title, description, path, image) {
+  constructor(name, title, description, path, image) {
+    this.name = name;
     this.title = title;
     this.description = description;
     this.path = path;
@@ -26,7 +27,7 @@ export default class Avatar {
       div({ class: `avatar ${size}` }, this.image ? div(this.getImage()) : div()),
       div(
         { class: 'avatar-info' },
-        div({ class: 'title' }, a({ href: this.path }, div(`${this.title}`))),
+        div({ class: 'name' }, a({ href: this.path }, div(`${this.name}`))),
         this.description ? div({ class: 'description info' }, this.description) : '',
       ),
     );
@@ -42,7 +43,7 @@ export default class Avatar {
       div({ class: `avatar ${size}` }, this.image ? div(this.getImage()) : div()),
       div(
         { class: 'avatar-details' },
-        h2(this.title),
+        h2(this.name),
         p(this.description),
         p(
           { class: 'link' },

--- a/aemedge/libs/pictureCard/pictureCard.js
+++ b/aemedge/libs/pictureCard/pictureCard.js
@@ -38,6 +38,7 @@ export default class PictureCard extends Card {
         { class: 'author-profile' },
         new Avatar(
           this.authorEntry.author,
+          this.authorEntry.title,
           this.authorEntry.description,
           this.authorEntry.path,
           this.authorEntry.image,


### PR DESCRIPTION
fix: author-profile cards now render the name and not the title. We mixed author name (index field: 'author') and title. This has been corrected.

Fix #410

Test URL 1: author profile at the bottom, title "Thomas Saueressig, Author at SAP News Center" must be replaced with name "Thomas Saueressig":
- Before: https://main--hlx-test--urfuwo.hlx.page/blog/2023/12/being-human-in-the-age-of-ai
- After: https://410-author-profiles-issues--hlx-test--urfuwo.hlx.live/blog/2023/12/being-human-in-the-age-of-ai

Test URL 2: author profile at the bottom, no name was shown, now name is shown:
- Before: https://main--hlx-test--urfuwo.hlx.page/blog/2024/02/sap-north-america-sales-performance-management-customer-summit-better-outcomes
- After: https://410-author-profiles-issues--hlx-test--urfuwo.hlx.live/blog/2024/02/sap-north-america-sales-performance-management-customer-summit-better-outcomes

Test URL 3: author profiles would show the title, now the name is shown (see Featured Editors sections):
- Before: https://main--hlx-test--urfuwo.hlx.page/draft/hupe/author-profiles-validation
- After: https://410-author-profiles-issues--hlx-test--urfuwo.hlx.live/draft/hupe/author-profiles-validation