### PR TITLE
Do Not Merge: Analytics Launch Delay Ref

### DIFF
--- a/aemedge/scripts/delayed.js
+++ b/aemedge/scripts/delayed.js
@@ -29,10 +29,8 @@ async function loadAdobeDC() {
   };
   const envType = getEnvType();
   if (envType && adobeTagsSrc[envType]) {
-    if (envType !== 'dev' || ((new URLSearchParams(window.location.search)).get('tr')) != null) {
-      await loadScript(adobeTagsSrc[envType], {});
-      await sendBeacon();
-    }
+    await loadScript(adobeTagsSrc[envType], {});
+    await sendBeacon();
   }
 }
 


### PR DESCRIPTION
chore: analytics launch delay analysis: reference value 3000ms. DEV tracking enabled per default

Fix #428

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
- After: https://428-analytics-launch-delay-ref--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
