### PR TITLE
DO NOT MERGE: Analytics Launch Delay L1

### DIFF
--- a/aemedge/scripts/adobedc.js
+++ b/aemedge/scripts/adobedc.js
@@ -1,0 +1,26 @@
+// eslint-disable-next-line import/no-cycle
+import { loadScript } from './aem.js';
+
+function getEnvType(hostname = window.location.hostname) {
+  const fqdnToEnvType = {
+    'www.sap.com': 'prod',
+    'www-qa.sap.com': 'stage',
+    'main--hlx-test--urfuwo.hlx.live': 'stage',
+  };
+  return fqdnToEnvType[hostname] || 'dev';
+}
+
+async function loadAdobeDC() {
+  const adobeTagsSrc = {
+    dev: 'https://assets.adobedtm.com/ccc66c06b30b/6fa889b263e0/launch-3318725e3375-development.min.js',
+    stage: 'https://assets.adobedtm.com/ccc66c06b30b/6fa889b263e0/launch-6615f1bb001d-staging.min.js',
+    prod: 'https://assets.adobedtm.com/ccc66c06b30b/6fa889b263e0/launch-69ede165613b.min.js',
+  };
+  const envType = getEnvType();
+  if (envType && adobeTagsSrc[envType]) {
+    await loadScript(adobeTagsSrc[envType], {});
+    window.console.log('# AdobeDC loaded');
+  }
+}
+
+await loadAdobeDC();

--- a/aemedge/scripts/delayed.js
+++ b/aemedge/scripts/delayed.js
@@ -1,39 +1,8 @@
 // eslint-disable-next-line import/no-cycle
-import { loadScript, sampleRUM } from './aem.js';
+import { sampleRUM } from './aem.js';
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
 // add more delayed functionality here
-
-function getEnvType(hostname = window.location.hostname) {
-  const fqdnToEnvType = {
-    'www.sap.com': 'prod',
-    'www-qa.sap.com': 'stage',
-    'main--hlx-test--urfuwo.hlx.live': 'stage',
-  };
-  return fqdnToEnvType[hostname] || 'dev';
-}
-
-async function sendBeacon(stl = null) {
-  window.adobeDataLayer.push({
-    event: stl ? 'stlBeaconReady' : 'stBeaconReady',
-  });
-}
-
-async function loadAdobeDC() {
-  const adobeTagsSrc = {
-    dev: 'https://assets.adobedtm.com/ccc66c06b30b/6fa889b263e0/launch-3318725e3375-development.min.js',
-    stage: 'https://assets.adobedtm.com/ccc66c06b30b/6fa889b263e0/launch-6615f1bb001d-staging.min.js',
-    prod: 'https://assets.adobedtm.com/ccc66c06b30b/6fa889b263e0/launch-69ede165613b.min.js',
-  };
-  const envType = getEnvType();
-  if (envType && adobeTagsSrc[envType]) {
-    if (envType !== 'dev' || ((new URLSearchParams(window.location.search)).get('tr')) != null) {
-      await loadScript(adobeTagsSrc[envType], {});
-      await sendBeacon();
-    }
-  }
-}
-
-await loadAdobeDC();
+window.console.log('# Delayed loaded');

--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -345,13 +345,35 @@ async function loadLazy(doc) {
  */
 function loadDelayed() {
   // eslint-disable-next-line import/no-cycle
-  window.setTimeout(() => import('./delayed.js'), 3000);
+  window.setTimeout(
+    () => import('./delayed.js'),
+    3000,
+  );
   // load anything that can be postponed to the latest here
 }
 
+async function scheduleAdobeDCLoad(start) {
+  // eslint-disable-next-line import/no-cycle
+  window.setTimeout(
+    () => import('./adobedc.js'),
+    250,
+  );
+  window.console.log(`# AdobeDC load scheduled at ${Date.now() - start}ms`);
+}
+
+async function sendAdobeDCBeacon(start, stl = null) {
+  window.adobeDataLayer.push({
+    event: stl ? 'stlBeaconReady' : 'stBeaconReady',
+  });
+  window.console.log(`Beacon sent at ${Date.now() - start}ms`);
+}
+
 async function loadPage() {
+  const start = Date.now();
   await loadEager(document);
+  await scheduleAdobeDCLoad(start);
   await loadLazy(document);
+  await sendAdobeDCBeacon(start);
   loadDelayed();
 }
 
@@ -361,7 +383,7 @@ async function initDataLayer() {
     event: 'globalDL',
     site: {
       country: 'glo',
-      name: 'sap',
+      name: 'l1',
     },
     user: {
       type: 'visitor',


### PR DESCRIPTION
chore: analytics launch delay: level 1. DEV tracking enabled per default, site name is l1 for identification

Fix #430

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
- After: https://430-analytics-launch-delay-l1--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
