### PR TITLE
Author names should not be clickable in cards

### DIFF
--- a/aemedge/libs/avatar/avatar.css
+++ b/aemedge/libs/avatar/avatar.css
@@ -46,12 +46,10 @@
   justify-content: center;
 
   & .name {
-    & a {
-      font-size: var(--udexTypographyBodyXSFontSize);
-      font-weight: var(--udexTypographyFontWeightMedium);
-      line-height: var(--udexTypographyDisplayLineHeight);
-      color: var(--udexColorNeutralBlack);
-    }
+    font-size: var(--udexTypographyBodyXSFontSize);
+    font-weight: var(--udexTypographyFontWeightMedium);
+    line-height: var(--udexTypographyDisplayLineHeight);
+    color: var(--udexColorNeutralBlack);
   }
 
   & .description {

--- a/aemedge/libs/avatar/avatar.js
+++ b/aemedge/libs/avatar/avatar.js
@@ -31,7 +31,7 @@ export default class Avatar {
       div({ class: `avatar ${size}` }, this.image ? div(this.getImage()) : div()),
       div(
         { class: 'avatar-info' },
-        div({ class: 'name' }, a({ href: this.path }, div(`${this.name}`))),
+        div({ class: 'name' }, div(`${this.name}`)),
         this.description ? div({ class: 'description info' }, this.description) : '',
       ),
     );

--- a/aemedge/libs/pictureCard/pictureCard.css
+++ b/aemedge/libs/pictureCard/pictureCard.css
@@ -21,6 +21,12 @@
     text-decoration: none;
   }
 
+  & .author.subtitle {
+    font-size: var(--udexTypographyBodyXSFontSize);
+    font-weight: var(--udexTypographyFontWeightMedium);
+    line-height: var(--udexTypographyDisplayLineHeight);
+  }
+
   & .cardcontent {
     padding: var(--udexSpacer16);
 
@@ -59,14 +65,6 @@
         font-size: var(--udexTypographyHeadingMediumXXSFontSize);
         font-weight: var(--udexTypographyFontWeightMedium);
         line-height: var(--udexTypographyHeadingLineHeight);
-      }
-    }
-
-    & .author {
-      & a {
-        font-size: var(--udexTypographyBodyXSFontSize);
-        font-weight: var(--udexTypographyFontWeightMedium);
-        line-height: var(--udexTypographyDisplayLineHeight);
       }
     }
   }

--- a/aemedge/libs/pictureCard/pictureCard.js
+++ b/aemedge/libs/pictureCard/pictureCard.js
@@ -40,7 +40,7 @@ export default class PictureCard extends Card {
       )
       : div(
         { class: 'author subtitle' },
-        a({ href: this.authorEntry.path }, span(`${this.authorEntry.author}`)),
+        span(`${this.authorEntry.author}`),
       );
   }
 

--- a/aemedge/templates/hub/hub.js
+++ b/aemedge/templates/hub/hub.js
@@ -1,8 +1,9 @@
 import { containerize } from '../../scripts/utils.js';
 import { aside } from '../../scripts/dom-builder.js';
-import { getMetadata } from '../../scripts/aem.js';
+import { getMetadata, loadCSS } from '../../scripts/aem.js';
 
 function decorate(doc) {
+  loadCSS(`${window.hlx.codeBasePath}/libs/pictureCard/pictureCard.css`);
   const main = doc.querySelector('main');
   containerize(main, '.hero');
   const template = getMetadata('template');

--- a/aemedge/templates/hub/hub.js
+++ b/aemedge/templates/hub/hub.js
@@ -1,9 +1,8 @@
 import { containerize } from '../../scripts/utils.js';
 import { aside } from '../../scripts/dom-builder.js';
-import { getMetadata, loadCSS } from '../../scripts/aem.js';
+import { getMetadata } from '../../scripts/aem.js';
 
 function decorate(doc) {
-  loadCSS(`${window.hlx.codeBasePath}/libs/pictureCard/pictureCard.css`);
   const main = doc.querySelector('main');
   containerize(main, '.hero');
   const template = getMetadata('template');


### PR DESCRIPTION
fix: author names should not be clickable in cards (both when an avatar image and when no avatar image is shown)

Fix #442

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/tags/sap-erp-hcm
- After: https://442-card-author-info-non-clickable--hlx-test--urfuwo.hlx.live/tags/sap-erp-hcm > horizonal and vertical cards with and without an avatar image

Test URL 2:
- Before: https://main--hlx-test--urfuwo.hlx.live/topics/ai
- After: https://442-card-author-info-non-clickable--hlx-test--urfuwo.hlx.live/topics/ai
