### PR TITLE
449: Hero spacing issues

### DIFF
--- a/aemedge/blocks/hero/hero.css
+++ b/aemedge/blocks/hero/hero.css
@@ -5,16 +5,6 @@ udex-hero-banner .hero-container {
 udex-hero-banner .hero-banner {
   width: 100%;
   container-type: inline-size;
-
-  h1 {
-    font-size: var(--udexTypographyHeadingMediumLFontSize);
-    font-weight: var(--udexTypographyFontWeightMedium);
-  }
-
-  h2 {
-    font-size: var(--udexTypographyHeadingMediumMFontSize);
-    font-weight: var(--udexTypographyFontWeightMedium);
-  }
 }
 
 udex-hero-banner .hero-banner p {
@@ -27,25 +17,35 @@ udex-hero-banner {
   container-name: hero-wrapper;
   display: block;
   width: 100%;
-}
 
-@container (max-width: 270px) {
-  udex-hero-banner .hero-banner ui5-button:first-of-type {
-    margin-bottom: 10px;
+  --udexHeroBannerContentPaddingVertical: 0;
+  --udexHeroBannerSlotMaxWidth: calc(50% - 2 * var(--udexHeroBannerContentPaddingHorizontal));
+
+  padding-block: var(--udexSpacer40);
+
+  @media (width >= 640px) {
+    --udexHeroBannerContentPaddingVertical: var(--udexSpacer40);
+
+    padding-block: 0;
+
+    .hero-banner.media-blend__additional-content {
+      padding-block-start: 0;
+    }
   }
-}
 
-/* Showcase */
-
-@container (max-width: 340px) {
-  udex-hero-banner .hero-banner--showcase .hero-banner__buttons {
-    margin-bottom: 24rem;
+  @media (width >= 980px) {
+    --udexHeroBannerContentPaddingVertical: var(--udexSpacer48);
   }
-}
 
-@container (max-width: 230px) {
-  udex-hero-banner .hero-banner--showcase .hero-banner__buttons {
-    margin-bottom: 16rem;
+  @media (width >= 1600px) {
+    --udexHeroBannerContentPaddingVertical: var(--udexSpacer56);
+  }
+
+  .hero-banner.media-blend__additional-content {
+    padding-block-start: var(--udexSpacer32);
+    display: flex;
+    align-items: center;
+    margin-inline-end: calc(var(--hero-margin--right) - 22px);
   }
 }
 
@@ -105,17 +105,59 @@ udex-hero-banner .hero-banner--image-above-cta {
   }
 }
 
-udex-hero-banner .hero-banner .media-blend__tags {
-  margin: var(--udexSpacer20) 0;
+udex-hero-banner .hero-banner.media-blend__content {
+  margin-left: calc(var(--hero-margin--left) - 22px);
+
+  h1 {
+    font-size: var(--udexTypographyHeadingMediumLFontSize);
+    font-weight: var(--udexTypographyFontWeightMedium);
+  }
+
+  > * {
+    margin-block-start: 0;
+  }
+
+  > *:not(:last-child) {
+    margin-block-end: var(--udexSpacer12);
+  }
+
+  h2 {
+    font-size: var(--udexTypographyHeadingMediumMFontSize);
+    font-weight: var(--udexTypographyFontWeightMedium);
+    margin-block-end: var(--udexSpacer16);
+  }
+
+  > *:last-child {
+    margin-block-end: 0;
+  }
+
+  @media (width >= 640px) {
+    > *:not(:last-child) {
+      margin-block-end: var(--udexSpacer20);
+    }
+
+    h2 {
+      margin-block-end: var(--udexSpacer20);
+    }
+
+    > *:last-child {
+      margin-block-end: 0;
+    }
+  }
 }
 
-udex-hero-banner .hero-banner .media-blend__intro-text {
+udex-hero-banner .hero-banner.media-blend__content .media-blend__intro-text {
   font-family: var(--sapFontFamily);
   font-size: var(--udexTypographyEyebrowMFontSize, 14px);
   font-weight: var(--udexTypographyFontWeightMedium);
   text-transform: uppercase;
   color: var(--udexColorGrey6, #5b738b);
   text-decoration: none;
+  margin-block-end: var(--udexSpacer8);
+
+  @media (width >= 640px) {
+    margin-block-end: var(--udexSpacer12);
+  }
 
   .eyebrow-arrow {
     display: inline-block;
@@ -127,27 +169,23 @@ udex-hero-banner .hero-banner .media-blend__intro-text {
     mask: url("/aemedge/icons/slim-arrow-left.svg") center no-repeat;
     background-color: currentcolor;
   }
-}
 
-udex-hero-banner .hero-banner .media-blend__intro-text a {
-  color: inherit;
-  text-decoration: inherit;
+  a {
+    color: inherit;
+    text-decoration: inherit;
 
-  &:visited {
-    color: var(--udexColorGrey9);
+    &:visited {
+      color: var(--udexColorGrey9);
+    }
+
+    &:hover {
+      color: var(--udexColorGrey8);
+    }
+
+    &:active {
+      color: var(--udexColorGrey10);
+    }
   }
-
-  &:hover {
-    color: var(--udexColorGrey8);
-  }
-
-  &:active {
-    color: var(--udexColorGrey10);
-  }
-}
-
-udex-hero-banner .hero-banner.media-blend__content {
-  margin-left: calc(var(--hero-margin--left) - 22px);
 }
 
 udex-hero-banner .hero-banner .media-blend__content ui5-rating-indicator {
@@ -158,18 +196,13 @@ udex-hero-banner .hero-banner .media-blend__content p {
   font-family: var(--sapFontFamily);
   font-size: var(--udexTypographyBodyLFontSize, 20px);
   color: var(--udexColorGrey9, #223548);
-  margin: var(--udexSpacer12, 12px) 0;
-}
-
-udex-hero-banner .hero-banner.media-blend__content :is(h2, h3) + p {
-  margin-block: 0;
 }
 
 udex-hero-banner .hero-banner .media-blend__info-block {
+  display: inline-block;
   font-family: var(--sapFontFamily);
   font-size: var(--udexTypographyBodyXSFontSize, 14px);
   color: var(--udexColorGrey7, #223548);
-  margin: var(--udexSpacer12, 12px) 0;
 }
 
 udex-hero-banner .hero-banner .media-blend__info-block .media-blend__authors::after {
@@ -209,33 +242,15 @@ udex-hero-banner .hero-banner a.media-blend__author {
   }
 }
 
-udex-hero-banner
-  .hero-banner
-  .media-blend__info-block
-  span:last-of-type::after {
+udex-hero-banner .hero-banner .media-blend__info-block span:last-of-type::after {
   margin: 0;
   content: '';
 }
 
-udex-hero-banner .hero-banner .media-blend__buttons {
-  margin-top: var(--udexSpacer40, 40px);
-}
-
-udex-hero-banner .hero-banner .media-blend__buttons udex-button:first-of-type {
-  margin-right: var(--udexSpacer16, 16px);
-}
-
-@container (width < 300px) {
-  udex-hero-banner .media-blend__buttons udex-button:first-of-type {
-    display: block;
-    margin-bottom: var(--udexSpacer12, 12px);
-  }
-}
-
-udex-hero-banner .hero-banner.media-blend__additional-content {
+udex-hero-banner .media-blend__buttons {
   display: flex;
-  align-items: center;
-  margin-right: calc(var(--hero-margin--right) - var(--udexSpacer8));
+  flex-wrap: wrap;
+  gap: var(--udexSpacer12) var(--udexSpacer16);
 }
 
 udex-hero-banner .custom-background-image {
@@ -318,20 +333,12 @@ udex-hero-banner .text-neutral-black {
   }
 }
 
-.hero-justify-wrapper udex-hero-banner {
-  h1 {
-    margin-top: 0;
-    margin-bottom: auto;
-    padding-bottom: var(--udexSpacer20);
-  }
+.hero-justify-wrapper udex-hero-banner .hero-banner.media-blend__content {
+  display: flex;
+  flex-direction: column;
 
   h1 + * {
     margin-top: auto;
-  }
-
-  .media-blend__content {
-    display: flex;
-    flex-direction: column;
   }
 }
 
@@ -341,10 +348,6 @@ udex-hero-banner .text-neutral-black {
   .custom-background-image {
     display: block
   }
-}
-
-.hero-container:has(.hero-no-bottom-space-wrapper) {
-  padding-bottom: 0;
 }
 
 .section.hero-container {

--- a/aemedge/blocks/hero/hero.css
+++ b/aemedge/blocks/hero/hero.css
@@ -18,27 +18,50 @@ udex-hero-banner {
   display: block;
   width: 100%;
 
-  --udexHeroBannerContentPaddingVertical: 0;
-  --udexHeroBannerSlotMaxWidth: calc(50% - 2 * var(--udexHeroBannerContentPaddingHorizontal));
+  --udexHeroBannerContentPaddingVertical: var(--udexSpacer40);
+  --udexHeroBannerSlotMaxWidth: calc(100% - 2 * var(--udexHeroBannerContentPaddingHorizontal));
 
-  padding-block: var(--udexSpacer40);
+  &:has(.media-blend__additional-content) {
+    --udexHeroBannerContentPaddingVertical: 0;
+    --udexHeroBannerSlotMaxWidth: calc(50% - 2 * var(--udexHeroBannerContentPaddingHorizontal));
+
+    .media-blend__content {
+      padding-block-start: 40px;
+    }
+
+    .media-blend__additional-content {
+      padding-block-end: 40px;
+    }
+  }
 
   @media (width >= 640px) {
     --udexHeroBannerContentPaddingVertical: var(--udexSpacer40);
 
-    padding-block: 0;
+    &:has(.media-blend__additional-content) {
+      --udexHeroBannerContentPaddingVertical: var(--udexSpacer40);
 
-    .hero-banner.media-blend__additional-content {
-      padding-block-start: 0;
+      .media-blend__content {
+        padding-block-start: 0;
+      }
+
+      .media-blend__additional-content {
+        padding-block-end: 0;
+      }
     }
   }
 
   @media (width >= 980px) {
     --udexHeroBannerContentPaddingVertical: var(--udexSpacer48);
+    --udexHeroBannerSlotMaxWidth: 540px;
+  }
+
+  @media (width >= 1300px) {
+    --udexHeroBannerSlotMaxWidth: 753px;
   }
 
   @media (width >= 1600px) {
     --udexHeroBannerContentPaddingVertical: var(--udexSpacer56);
+    --udexHeroBannerSlotMaxWidth: 936px;
   }
 
   .hero-banner.media-blend__additional-content {
@@ -47,6 +70,7 @@ udex-hero-banner {
     align-items: center;
     margin-inline-end: calc(var(--hero-margin--right) - 22px);
   }
+
 }
 
 /* Additional content */

--- a/aemedge/templates/article/article.css
+++ b/aemedge/templates/article/article.css
@@ -53,6 +53,10 @@ main {
       margin-inline-end: var(--udexGridMargins);
     }
 
+    & > .hero-container ~ [data-location='sidebar']  {
+      margin-block-start: var(--udexSpacer84);
+    }
+
     & > [data-location='document-footer'] {
       grid-column: -3 / span 2;
       margin-inline: var(--udexGridMargins);
@@ -89,8 +93,11 @@ main {
     }
 
     & > .hero-container {
-      margin-block-end: var(--udexSpacer84);
       grid-column: 1 / -1;
+    }
+
+    & > .hero-container + .section {
+      padding-block-start: var(--udexSpacer84);
     }
 
     & > .toc-container {

--- a/aemedge/templates/hub/hub.css
+++ b/aemedge/templates/hub/hub.css
@@ -98,8 +98,8 @@
 
   & > main {
     @media (width >= 980px) {
-      & .hero-container {
-        margin-block-end: 84px;
+      & .hero-container + .section {
+        padding-block-start: 84px;
       }
 
       & > :not(.hero-container, .title-banner-container) {


### PR DESCRIPTION
- Hero background should be continuous with background of following section (i.e. no white margin between sections with colourful backgrounds)
- Spacing between hero content elements should now more closely match the Figma designs.
- Hero text content width should take up more of the space at larger screen sizes as per Figma.
- Vertical hero padding should adjust according to breakpoints (40px -> 48px -> 56px);

Fix #449

Test URLs:
Design Page with hero margin issue
- Before: https://main--hlx-test--urfuwo.hlx.live/design/stories-resources
- After: https://449-hero-bottom-margin--hlx-test--urfuwo.hlx.live/design/stories-resources

L3
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/ext-how-ai-powered-cybersecurity-combats-ai-threats
- After: https://449-hero-bottom-margin--hlx-test--urfuwo.hlx.live/blog/ext-how-ai-powered-cybersecurity-combats-ai-threats

L2
- Before: https://main--hlx-test--urfuwo.hlx.live/topics/sustainability
- After: https://449-hero-bottom-margin--hlx-test--urfuwo.hlx.live/topics/sustainability

L1
- Before: https://main--hlx-test--urfuwo.hlx.live/topics
- After: https://449-hero-bottom-margin--hlx-test--urfuwo.hlx.live/topics
