### PR TITLE
chore: Introducing default query index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,6 +1,30 @@
-version: 1
+version: 2
 indices:
   default:
+    include:
+      - /**
+    exclude:
+      - '/drafts/**'
+      - '/tools/sidekick/**'
+      - '/fragments/**'
+    target: /aemedge/query-index.json
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      robots:
+        select: head > meta[name="robots"]
+        value: attribute(el, "content")
+      lastModified:
+        select: none
+        value: parseTimestamp(headers["last-modified"])
+      template:
+        select: head > meta[name="template"]
+        value: attribute(el, "content")
+      content-type:
+        select: head > meta[name="content-type"]
+        value: attribute(el, "content")
+  articles:
     include:
       - /blog/**
       - /news/**
@@ -51,7 +75,7 @@ indices:
       description:
         select: head > meta[name="description"]
         value: attribute(el, "content")
-  author:
+  authors:
     include:
       - /author/**
     exclude:


### PR DESCRIPTION
Added a default index for whole content tree to be used in sitemap and other programmatic functions
