### PR TITLE
207 - Track user login status - iteration 1

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -357,6 +357,7 @@ async function loadPage() {
 
 async function initDataLayer() {
   window.adobeDataLayer = [];
+  const loginStatus = window.sessionStorage.getItem('loginStatus') === 'logY' ? 'yes' : 'no';
   window.adobeDataLayer.push({
     event: 'globalDL',
     site: {
@@ -365,7 +366,7 @@ async function initDataLayer() {
     },
     user: {
       type: 'visitor',
-      loginStatus: 'no',
+      loginStatus,
     },
   });
   const relpath = window.location.pathname.substring(1);
@@ -382,7 +383,7 @@ async function initDataLayer() {
     },
     user: {
       type: 'visitor',
-      loginStatus: 'no',
+      loginStatus,
     },
   });
 }


### PR DESCRIPTION
fix: reflect user login status in data layer, iteration 1 (for details see ticket #207)

Ref: https://adobe-dx-support.slack.com/archives/C06SB3177F1/p1712591740928939?thread_ts=1712231909.703159&cid=C06SB3177F1

Fix #207 

Test URLs:
- Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
- After: https://207-analytics-user-login-status--hlx-test--urfuwo.hlx.page/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications

Test case on QA after deployment:
- Register on www-qa.sap.com (header)
- Login on www-qa.sap.com
- Navigate to www-qa.sap.com/blogs/
- Inspect data layer (browser console: adobeDataLayer.getState() > user > loginStatus should be 'yes' when logged in, 'no' when not logged in)