### PR TITLE
341: Picture cards fine alignment and styling tweaks

### DIFF
--- a/aemedge/blocks/content-list/content-list.css
+++ b/aemedge/blocks/content-list/content-list.css
@@ -76,7 +76,6 @@ body.hub-l2 .content-list {
 @container content-list (width >= 640px) {
   .content-list ul {
     grid-template-columns: repeat(3, 1fr);
-    grid-auto-rows: 115px 80px 90px;
   }
 
   .content-list.wide ul {
@@ -87,7 +86,6 @@ body.hub-l2 .content-list {
 @container content-list (width >= 980px) {
   .content-list ul {
     grid-template-columns: repeat(4, 1fr);
-    grid-auto-rows: 115px 80px 70px;
   }
 
   .content-list.wide ul {

--- a/aemedge/blocks/featured-articles/featured-articles.css
+++ b/aemedge/blocks/featured-articles/featured-articles.css
@@ -27,9 +27,15 @@
       display: grid;
       grid-auto-flow: row;
       grid-auto-rows: 1fr;
-      grid-template-columns: 3fr 2fr;
+      grid-template-columns: 1fr;
       grid-gap: var(--udexGridGutters);
       padding: 0;
+
+      @media (width >= 640px) {
+        & {
+          grid-template-columns: 3fr 2fr;
+        }
+      }
     }
   }
 }

--- a/aemedge/libs/avatar/avatar.css
+++ b/aemedge/libs/avatar/avatar.css
@@ -61,6 +61,10 @@
     font-weight: var(--udexTypographyFontWeightMedium);
     line-height: var(--udexTypographyDisplayLineHeight);
     color: var(--udexColorNeutralBlack);
+
+    &:not(:last-child) {
+      margin-block-end: var(--udexSpacer4);
+    }
   }
 
   & .description {
@@ -95,4 +99,9 @@
   box-shadow: 0 2px 4px rgb(34 54 73 / 20%);
   background-color: var(--background-color);
   border-radius: var(--sapTile_BorderCornerRadius);
+  align-items: center;
+
+  &:has(.description) {
+    align-items: flex-start;
+  }
 }

--- a/aemedge/libs/pictureCard/pictureCard.css
+++ b/aemedge/libs/pictureCard/pictureCard.css
@@ -1,31 +1,33 @@
 .picture-card {
-  display: grid;
-  grid-template-rows: subgrid;
-  grid-row: span 3;
-  gap: 0;
-  box-shadow: 0 2px 4px rgb(34 54 73 / 20%);
-  background-color: var(--background-color);
-  border-radius: var(--sapTile_BorderCornerRadius);
   position: relative;
+  height: 360px;
 
   & a {
-    text-decoration: none;
-
     --card-image-height: 130px;
 
-    display: grid;
-    grid-template-rows: subgrid;
-    grid-row: span 3;
-    gap: 0;
-    box-shadow: 0 2px 4px rgb(34 54 73 / 20%);
+    height: 100%;
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
     background-color: var(--background-color);
-    border-radius: var(--sapTile_BorderCornerRadius);
+    border-radius: var(--udexRadiusL);
+    box-shadow: 0 var(--udexSpacer2) var(--udexSpacer4) rgb(34 54 73 / 20%);
     overflow: hidden;
     position: relative;
 
+    .picture {
+      height: var(--card-image-height);
+      flex-shrink: 0;
+
+      picture {
+        display: block;
+        height: 100%;
+      }
+    }
+
     & img {
       width: 100%;
-      height: var(--card-image-height);
+      height: 100%;
       object-fit: cover;
     }
 
@@ -34,10 +36,13 @@
       font-weight: var(--udexTypographyFontWeightMedium);
       line-height: var(--udexTypographyDisplayLineHeight);
       color: var(--text-color);
+      margin-bottom: var(--udexSpacer4);
     }
 
     & .cardcontent {
-      padding: var(--udexSpacer16);
+      padding: var(--udexSpacer16) var(--udexSpacer20) var(--udexSpacer12) var(--udexSpacer20);
+      flex-grow: 1;
+      flex-shrink: 1;
 
       & .type {
         font-size: var(--udexTypographyEyebrowSFontSize);
@@ -59,25 +64,34 @@
         border-radius: var(--udexRadiusS);
         font-size: var(--udexTypographyBodyXXSFontSize);
         font-weight: var(--udexTypographyFontWeightRegular);
-        line-height: var(--udexTypographyHeadingLineHeight);
+        line-height: var(--udexTypographyBodyLineHeight);
         color: var(--udexColorBlue9);
       }
 
       & .title {
         display: -webkit-box;
-        -webkit-line-clamp: 5;
+        -webkit-line-clamp: 4;
         -webkit-box-orient: vertical;
         overflow: hidden;
         text-wrap: pretty;
-
         font-size: var(--udexTypographyHeadingMediumXXSFontSize);
         font-weight: var(--udexTypographyFontWeightMedium);
         line-height: var(--udexTypographyHeadingLineHeight);
       }
+
+      .description {
+        font-size: var(--udexTypographyBodyXSFontSize);
+        line-height: var(--udexTypographyBodyLineHeight);
+        color: var(--udexColorNeutralBlack);
+        margin: 0;
+        margin-block-start: var(--udexSpacer16);
+        display: none;
+      }
     }
 
     & .infoblock {
-      padding: var(--udexSpacer16);
+      padding: 0 var(--udexSpacer20) var(--udexSpacer24) var(--udexSpacer20);
+      flex-shrink: 0;
 
       & .author-profile {
         display: block;
@@ -114,60 +128,54 @@
       }
     }
   }
+}
 
-  &.horizontal {
+@media (width >= 640px) {
+  .picture-card.horizontal {
+    display: grid;
+    grid-template-rows: subgrid;
     grid-template-columns: subgrid;
     grid-column: 1 / -1;
+    grid-column-gap: var(--udexSpacer24);
+    height: min-content;
 
     & a {
       grid-template-columns: subgrid;
-      grid-template-rows: unset;
       grid-column: 1 / -1;
-      overflow: unset; /* Safari bug */
-
-      @media (width < 640px) {
-        display: block;
-        overflow: hidden;
-      }
+      grid-template-rows: 1fr min-content;
+      display: grid;
 
       & .cardcontent {
         order: -1;
+        padding: var(--udexSpacer24) 0 var(--udexSpacer12) var(--udexSpacer24);
+
+        & .tag-label {
+          inset: var(--udexSpacer32) var(--udexSpacer32) auto auto;
+        }
 
         & .description {
-          color: var(--udexColorNeutralBlack);
-
-          @media (width < 640px) {
-            display: none;
-          }
+          display: block;
         }
       }
 
       & .picture {
         order: 1;
-        padding: var(--udexSpacer16);
         grid-row: span 2;
-
-        @media (width < 640px) {
-          padding: unset;
-        }
+        padding: var(--udexSpacer24) var(--udexSpacer20) var(--udexSpacer24) 0;
+        height: auto;
 
         & img {
           max-width: 100%;
-          height: 100%;
           object-fit: cover;
           aspect-ratio: unset;
-          border-radius: 12px;
-
-          @media (width < 640px) {
-            height: var(--card-image-height);
-            border-radius: unset;
-          }
+          height: 100%;
+          border-radius: var(--udexRadiusM);
         }
       }
 
       & .infoblock {
         order: 3;
-        padding: 0 var(--udexSpacer16) var(--udexSpacer16) var(--udexSpacer16);
+        padding: 0 0 var(--udexSpacer24) var(--udexSpacer24);
       }
     }
   }


### PR DESCRIPTION
- Adjust border radius, text sizes, spacing for both vertical and horizontal picture cards (content list and featured articles) to match Frontify more closely (https://sap.frontify.com/document/223143#/-/resource-center) and address issues spotted by Elaine (https://adobe-dx-support.slack.com/archives/C06H8UNQ3RS/p1710798138014269?thread_ts=1710770896.748139&cid=C06H8UNQ3RS).
- Vertical picture card now uses flexbox rather than grid to layout contents, as elements (specifically info box for avatar and readtime/date) can vary in height between cards depending on availability of information).
- Text only cards should not be affected.

Fix #341

Test URLs:
**Content Hub:**
Before: https://main--hlx-test--urfuwo.hlx.live/topics/
After: https://341-fine-alignment-on-picture-card--hlx-test--urfuwo.hlx.live/topics/
