### PR TITLE
355: Fix sizing of TOC column in article grid.

### DIFF
--- a/aemedge/templates/article/article.css
+++ b/aemedge/templates/article/article.css
@@ -15,11 +15,14 @@ main {
   grid-auto-flow: row;
   column-gap: var(--udexGridGutters);
   margin-block-end: var(--udexSpacer84);
+  margin-inline: var(--udexGridMargins);
 
-  @media (width < 980px) {
-    & > :not(.hero-container) {
-      margin-inline: var(--udexGridMargins);
-    }
+  & .hero-container, [data-location='document-footer']:is(.section.background-dark, .section.background-light) {
+    margin-inline: calc(-1 * var(--udexGridMargins));
+  }
+
+  [data-location='document-footer']:is(.section.background-dark, .section.background-light) {
+    padding-inline: var(--udexGridMargins);
   }
 
   & > * {
@@ -30,7 +33,7 @@ main {
   }
 
   @media (width >= 980px) {
-    grid-template-columns: 8fr 4fr;
+    grid-template-columns: minmax(0, 8fr) minmax(0, 4fr);
     grid-template-rows: repeat(99, auto);
 
     &
@@ -43,14 +46,12 @@ main {
           )
       ) {
       grid-column: 1 / 2;
-      margin-inline-start: var(--udexGridMargins);
       padding-block-end: 56px;
     }
 
     & > [data-location='sidebar'] {
       grid-column: 2 / 3;
       grid-row: -3 / -2;
-      margin-inline-end: var(--udexGridMargins);
     }
 
     & > .hero-container ~ [data-location='sidebar']  {
@@ -59,23 +60,20 @@ main {
 
     & > [data-location='document-footer'] {
       grid-column: -3 / span 2;
-      margin-inline: var(--udexGridMargins);
       padding-block-end: 84px;
     }
 
     /* if page has table of contents it has a 3 column layout */
     &:has(.toc-container) {
-      grid-template-columns: 3fr 6fr 3fr;
+      grid-template-columns: minmax(0, 3fr) minmax(0, 6fr) minmax(0, 3fr);
 
       & > [data-location='sidebar'] {
         grid-column: 3 / 4;
         grid-row: 2 / -2;
-        margin-inline-end: var(--udexGridMargins);
       }
 
       & > [data-location='document-footer'] {
         grid-column: -4 / span 3;
-        margin-inline: var(--udexGridMargins);
       }
 
       &
@@ -103,7 +101,6 @@ main {
     & > .toc-container {
       grid-column: 1 / 2;
       grid-row: 2 / -2;
-      margin-inline-start: var(--udexGridMargins);
       min-width: 18ch;
     }
   }

--- a/aemedge/templates/article/article.css
+++ b/aemedge/templates/article/article.css
@@ -51,7 +51,7 @@ main {
 
     & > [data-location='sidebar'] {
       grid-column: 2 / 3;
-      grid-row: -3 / -2;
+      grid-row: 2 / -2;
     }
 
     & > .hero-container ~ [data-location='sidebar']  {

--- a/aemedge/templates/article/article.js
+++ b/aemedge/templates/article/article.js
@@ -7,7 +7,7 @@ function decorate(doc) {
   const main = doc.querySelector('main');
   containerize(main, '.hero');
   const tocFlag = getMetadata('toc');
-  if (tocFlag && tocFlag.content !== 'no' && tocFlag.content !== 'false') {
+  if (tocFlag && tocFlag !== 'no' && tocFlag !== 'false') {
     const tocSection = div({ class: 'toc-container' }, div({ class: 'toc' }));
     main.insertBefore(tocSection, doc.querySelector('main > :nth-child(2)'));
   }


### PR DESCRIPTION
Currently as margins are added to the grid content rather than the grid itself, the column widths are not calculated correctly. If we  add margins on the grid level rather than section and add negative margin and padding to sections with background colour (and hero) we can ensure the correct sizing.
It also happened that the `toc` hide/show metadata config wasn't being read correctly so that is also resolved here. If it was intended for TOC to be mandatory on all article pages I can revert that change.

Fix #355

Test URLs:
**Content Hub:**
Before: https://main--hlx-test--urfuwo.hlx.live/draft/rjwtrmn/the-article-copy
After: https://<branch>--hlx-test--urfuwo.hlx.live/draft/rjwtrmn/the-article-copy
Before: https://main--hlx-test--urfuwo.hlx.live/draft/rjwtrmn/the-article-copy-without-toc
After: https://<branch>--hlx-test--urfuwo.hlx.live/draft/rjwtrmn/the-article-copy-without-toc
