### PR TITLE
491: TOC sticky in mobile view

### DIFF
--- a/aemedge/blocks/toc/toc.css
+++ b/aemedge/blocks/toc/toc.css
@@ -12,6 +12,7 @@
 }
 
 button.toc__selected {
+  position: relative;
   box-shadow: 0 var(--udexSpacer2) var(--udexSpacer8) 0 #2236494d;
   border-radius: 0.25rem;
   appearance: none;
@@ -19,6 +20,7 @@ button.toc__selected {
   background-color: var(--udexColorNeutralWhite);
   font: inherit;
   width: 100%;
+  z-index: 2;
 
   &::after {
     transform: rotate(90deg);
@@ -28,7 +30,6 @@ button.toc__selected {
 
 .toc-wrapper {
   height: 100%;
-  margin-bottom: var(--udexSpacer56);
 }
 
 .toc {
@@ -48,6 +49,8 @@ button.toc__selected {
     box-shadow: 0 var(--udexSpacer2) var(--udexSpacer8) 0 #2236494d;
     padding-block-start: var(--udexSpacer16);
     width: 100%;
+    background-color: var(--udexColorNeutralWhite);
+    z-index: 1;
   }
 
   button.toc__selected,
@@ -106,6 +109,7 @@ button.toc__selected {
   border-bottom: 0.0625rem solid var(--udexColorBlue7);
   border-end-end-radius: 0;
   border-end-start-radius: 0;
+  padding-block-end: calc(12.5px - 0.0625rem);
 
   &::after {
     background-color: var(--udexColorBlue7);
@@ -144,6 +148,10 @@ button.toc__selected {
 }
 
 @media (width >= 980px) {
+  .toc-container {
+    position: static;
+  }
+
   .toc__list {
     display: block;
   }

--- a/aemedge/templates/article/article.css
+++ b/aemedge/templates/article/article.css
@@ -32,9 +32,31 @@ main {
     transition-timing-function: ease-in-out;
   }
 
+  > .hero-container + .section {
+    padding-block-start: var(--udexSpacer56);
+  }
+
+  > .toc-container {
+    margin-block-end: var(--udexSpacer40);
+    position: sticky;
+    top: calc(-1 * var(--udexSpacer32));
+    z-index: 2;
+  }
+
   @media (width >= 980px) {
     grid-template-columns: minmax(0, 8fr) minmax(0, 4fr);
     grid-template-rows: repeat(99, auto);
+
+    & > [data-location='sidebar'] {
+      grid-column: 2 / 3;
+      grid-row: 2 / -2;
+    }
+
+    > .hero-container + .section,
+    > .toc-container + .section,
+    > .hero-container ~ [data-location='sidebar'] {
+      padding-block-start: var(--udexSpacer84);
+    }
 
     &
       > :not(
@@ -47,15 +69,6 @@ main {
       ) {
       grid-column: 1 / 2;
       padding-block-end: 56px;
-    }
-
-    & > [data-location='sidebar'] {
-      grid-column: 2 / 3;
-      grid-row: 2 / -2;
-    }
-
-    & > .hero-container ~ [data-location='sidebar']  {
-      margin-block-start: var(--udexSpacer84);
     }
 
     & > [data-location='document-footer'] {
@@ -86,7 +99,6 @@ main {
             )
         ) {
         grid-column: 2 / 3;
-        margin-inline-start: unset;
       }
     }
 
@@ -94,14 +106,12 @@ main {
       grid-column: 1 / -1;
     }
 
-    & > .hero-container + .section {
-      padding-block-start: var(--udexSpacer84);
-    }
-
     & > .toc-container {
       grid-column: 1 / 2;
       grid-row: 2 / -2;
       min-width: 18ch;
+      margin-block-end: var(--udexSpacer56);
+      position: static;
     }
   }
 


### PR DESCRIPTION
Make TOC sticky for mobile. Added additional event handling to close menu on click outside/esc/focus out

Fix #491

Test URLs:
**Content Hub:**
Before: https://main--hlx-test--urfuwo.hlx.live/draft/rjwtrmn/the-article-copy
After: https://491-sticky-toc-mobile--hlx-test--urfuwo.hlx.live/draft/rjwtrmn/the-article-copy
