### PR TITLE
chore: rework tags for L3 pages

### DIFF
--- a/aemedge/blocks/article-tags/article-tags.js
+++ b/aemedge/blocks/article-tags/article-tags.js
@@ -1,14 +1,26 @@
 import {
-  getMetadata, fetchPlaceholders,
+  getMetadata,
+  toCamelCase,
 } from '../../scripts/aem.js';
 import { div } from '../../scripts/dom-builder.js';
 import Tag from '../../libs/tag/tag.js';
+import { fetchTagList } from '../../scripts/utils.js';
 
 export default async function decorate(block) {
-  const tags = getMetadata('article:tag');
-  if (tags) {
-    const placeholders = await fetchPlaceholders();
-    const tagsLiEL = tags.split(',').map((tag) => new Tag(tag, placeholders).render());
+  const articleTags = getMetadata('article:tag');
+  if (articleTags) {
+    const tags = await fetchTagList();
+    const tagsLiEL = articleTags.split(', ').map((articleTag) => {
+      let tag = tags[toCamelCase(articleTag)];
+      if (!tag) { // fallback for tags we haven't mapped
+        const articleTagArr = articleTag.split('/');
+        tag = { key: articleTag, label: articleTag, 'topic-path': `/topics/${articleTagArr[1]}` };
+        if (articleTagArr[0] === 'news-tag') {
+          tag['news-path'] = `/news/${articleTagArr[1]}`;
+        }
+      }
+      return new Tag(tag).render();
+    });
     const tagListEl = div({ class: 'tag-list' }, ...tagsLiEL);
     block.append(tagListEl);
   }

--- a/aemedge/blocks/related-articles/related-articles.js
+++ b/aemedge/blocks/related-articles/related-articles.js
@@ -4,7 +4,7 @@ import {
 } from '../../scripts/aem.js';
 import ffetch from '../../scripts/ffetch.js';
 import PictureCard from '../../libs/pictureCard/pictureCard.js';
-import { formatDate } from '../../scripts/utils.js';
+import { fetchTagList, formatDate } from '../../scripts/utils.js';
 import { allAuthorEntries, authorEntry } from '../../scripts/article.js';
 
 function getFilter(pageTags) {
@@ -20,26 +20,33 @@ function getFilter(pageTags) {
 
 function getPictureCard(article, placeholders, authEntry) {
   const {
-    'content-type': type, image, path, title, priority,
+    contentType, image, path, title, priority,
   } = article;
+
   const tagLabel = placeholders[toCamelCase(priority)] || '';
   const info = `Updated on ${formatDate(article.publicationDate * 1000)}`;
-  return new PictureCard(title, path, type, info, authEntry, image, tagLabel);
+  return new PictureCard(title, path, contentType, info, authEntry, image, tagLabel);
 }
 
 export default async function decorateBlock(block) {
   const pageTags = getMetadata('article:tag').split(', ');
   const filter = getFilter(pageTags);
   const limit = 4;
-  const articleStream = await ffetch(`${window.hlx.codeBasePath}/articles-index.json`)
+  const articles = await ffetch(`${window.hlx.codeBasePath}/articles-index.json`)
     .filter(filter)
     .limit(limit)
     .slice(0, limit - 1)
     .all();
   const placeholders = await fetchPlaceholders();
-  const authEntries = await allAuthorEntries(articleStream);
+  const tags = await fetchTagList();
+  const authEntries = await allAuthorEntries(articles);
   const cardList = ul();
-  articleStream.forEach((article) => {
+  articles.forEach((article) => {
+    const contentType = JSON.parse(article.tags).find((tag) => tag.startsWith('content-type'));
+    if (contentType) {
+      article.contentType = tags[toCamelCase(contentType)]?.label || '';
+    }
+
     const card = getPictureCard(article, placeholders, authorEntry(article, authEntries));
     cardList.append(card.render());
   });

--- a/aemedge/blocks/related-articles/related-articles.js
+++ b/aemedge/blocks/related-articles/related-articles.js
@@ -1,6 +1,6 @@
 import { ul } from '../../scripts/dom-builder.js';
 import {
-  getMetadata, fetchPlaceholders, toCamelCase, toClassName,
+  getMetadata, fetchPlaceholders, toCamelCase,
 } from '../../scripts/aem.js';
 import ffetch from '../../scripts/ffetch.js';
 import PictureCard from '../../libs/pictureCard/pictureCard.js';
@@ -28,11 +28,9 @@ function getPictureCard(article, placeholders, authEntry) {
 }
 
 export default async function decorateBlock(block) {
-  const pageTags = getMetadata('article:tag')
-    .split(',')
-    .map((tag) => toClassName(tag.trim()));
+  const pageTags = getMetadata('article:tag').split(', ');
   const filter = getFilter(pageTags);
-  const limit = 4; // hardcoded for now
+  const limit = 4;
   const articleStream = await ffetch(`${window.hlx.codeBasePath}/articles-index.json`)
     .filter(filter)
     .limit(limit)

--- a/aemedge/libs/tag/tag.js
+++ b/aemedge/libs/tag/tag.js
@@ -1,17 +1,21 @@
-import { loadCSS, toCamelCase, toClassName } from '../../scripts/aem.js';
+import { loadCSS } from '../../scripts/aem.js';
 import { a } from '../../scripts/dom-builder.js';
 
 export default class Tag {
-  tagText;
+  tag;
 
-  constructor(tag, placeholders = []) {
-    this.tagText = (placeholders[toCamelCase(`tag/${tag}`)] || tag).trim();
+  constructor(tag) {
+    this.tag = tag;
   }
 
   render(excludeStyles) {
     if (!excludeStyles) {
       loadCSS(`${window.hlx.codeBasePath}/libs/tag/tag.css`);
     }
-    return a({ class: 'tag', href: `/tags/${toClassName(this.tagText)}` }, this.tagText);
+    let tagHref = this.tag['topic-path'];
+    if (document.location.pathname.startsWith('/news/') && this.tag['news-path']) {
+      tagHref = this.tag['news-path'];
+    }
+    return a({ class: 'tag', href: tagHref }, this.tag.label);
   }
 }

--- a/aemedge/scripts/utils.js
+++ b/aemedge/scripts/utils.js
@@ -1,3 +1,4 @@
+import { getMetadata, toCamelCase } from './aem.js';
 import { div } from './dom-builder.js';
 
 function formatDate(inputDate) {
@@ -24,4 +25,42 @@ function containerize(container, targetClass) {
   }
 }
 
-export { formatDate, containerize };
+async function fetchTagList(prefix = 'default') {
+  window.tags = window.tags || {};
+  if (!window.tags[prefix]) {
+    window.tags[prefix] = new Promise((resolve) => {
+      fetch(`${prefix === 'default' ? '/aemedge' : prefix}/tagging-contenthub.json`)
+        .then((resp) => {
+          if (resp.ok) {
+            return resp.json();
+          }
+          return {};
+        })
+        .then((json) => {
+          const tags = {};
+          json.data
+            .filter((tag) => tag.key)
+            .forEach((tag) => {
+              tags[toCamelCase(tag.key)] = tag;
+            });
+          window.tags[prefix] = tags;
+          resolve(window.tags[prefix]);
+        })
+        .catch(() => {
+          // error loading placeholders
+          window.tags[prefix] = {};
+          resolve(window.tags[prefix]);
+        });
+    });
+  }
+  return window.tags[`${prefix}`];
+}
+
+function getContentType() {
+  const tags = getMetadata('article:tag').split(', ');
+  return tags.find((tag) => tag.trim().toLowerCase().startsWith('content-type'));
+}
+
+export {
+  formatDate, containerize, fetchTagList, getContentType,
+};

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -42,20 +42,11 @@ indices:
       author:
         select: head > meta[name="author"]
         value: attribute(el, "content")
-      display-author:
-        select: head > meta[name="display-author"]
-        value: attribute(el, "content")
       priority:
         select: head > meta[name="priority"]
         value: attribute(el, "content")
-      content-type:
-        select: head > meta[name="content-type"]
-        value: attribute(el, "content")
       tags:
         select: head > meta[property="article:tag"]
-        values: attribute(el, "content")
-      topics:
-        select: head > meta[name="topics"]
         values: attribute(el, "content")
       image:
         select: head > meta[property="og:image"]


### PR DESCRIPTION
Relates #391 

Change to new single tag fields for tag usage on L3 pages:
* update hero for eyebrow and first tag
* update article tags
* update related article cards

Test URLs:
Before: https://main--hlx-test--urfuwo.hlx.live/news/2020/02/sap-proaxia-intelligent-enterprise-solution-automotive-retail-sap-s-4hana

After: https://feat-391-tagging--hlx-test--urfuwo.hlx.live/news/2020/02/sap-proaxia-intelligent-enterprise-solution-automotive-retail-sap-s-4hana
Test 2: https://feat-391-tagging--hlx-test--urfuwo.hlx.live/news/2020/02/sap-io-foundry-munich-cohort-acceleration-program-marketing-commerce-startups
Test 3: https://feat-391-tagging--hlx-test--urfuwo.hlx.live/blog/2020/02/doehler-goodyear-intelligent-enterprise-sap-s4hana