### PR TITLE
500: Account for pages without content type.

### DIFF
--- a/aemedge/blocks/hero/hero.js
+++ b/aemedge/blocks/hero/hero.js
@@ -118,7 +118,6 @@ export default async function decorate(block) {
   let eyebrowText = eyebrow?.textContent;
   const contentTypeTag = tags[toCamelCase(getContentType())];
 
-  // TODO tag translation
   if (!eyebrowText && isArticle) {
     // if no eyebrow text is set, use the content type for articles
     eyebrowText = contentTypeTag?.label || getContentType()?.split('/')[1].replace('-', ' ');

--- a/aemedge/blocks/hero/hero.js
+++ b/aemedge/blocks/hero/hero.js
@@ -121,7 +121,7 @@ export default async function decorate(block) {
   // TODO tag translation
   if (!eyebrowText && isArticle) {
     // if no eyebrow text is set, use the content type for articles
-    eyebrowText = contentTypeTag?.label || getContentType().split('/')[1].replace('-', ' ');
+    eyebrowText = contentTypeTag?.label || getContentType()?.split('/')[1].replace('-', ' ');
   }
 
   const eyebrowArrow = span({ class: 'eyebrow-arrow' });


### PR DESCRIPTION
Small fix to account for no content-type/x returned from metadata.

Fix #500

Test URLs:
**Content Hub:**
Before: https://main--hlx-test--urfuwo.hlx.live/blog/ext-how-ai-powered-cybersecurity-combats-ai-threats
After: https://500-optional-chaining-fix--hlx-test--urfuwo.hlx.live/blog/ext-how-ai-powered-cybersecurity-combats-ai-threats
