### PR TITLE
chore: fix article tag cloud and filter internal tags

### DIFF
--- a/aemedge/blocks/article-tags/article-tags.js
+++ b/aemedge/blocks/article-tags/article-tags.js
@@ -10,15 +10,11 @@ export default async function decorate(block) {
   const articleTags = getMetadata('article:tag');
   if (articleTags) {
     const tags = await fetchTagList();
-    const tagsLiEL = articleTags.split(', ').map((articleTag) => {
-      let tag = tags[toCamelCase(articleTag)];
-      if (!tag) { // fallback for tags we haven't mapped
-        const articleTagArr = articleTag.split('/');
-        tag = { key: articleTag, label: articleTag, 'topic-path': `/topics/${articleTagArr[1]}` };
-        if (articleTagArr[0] === 'news-tag') {
-          tag['news-path'] = `/news/${articleTagArr[1]}`;
-        }
-      }
+    const tagsLiEL = articleTags.split(', ').filter((articleTag) => {
+      const tag = tags[toCamelCase(articleTag)];
+      return tag && (tag['topic-path'] || tag['news-path']);
+    }).map((articleTag) => {
+      const tag = tags[toCamelCase(articleTag)];
       return new Tag(tag).render();
     });
     const tagListEl = div({ class: 'tag-list' }, ...tagsLiEL);

--- a/aemedge/blocks/hero/hero.js
+++ b/aemedge/blocks/hero/hero.js
@@ -2,9 +2,7 @@ import '@udex/webcomponents/dist/HeroBanner.js';
 import {
   a, div, p, span,
 } from '../../scripts/dom-builder.js';
-import {
-  fetchPlaceholders, getMetadata, toCamelCase,
-} from '../../scripts/aem.js';
+import { getMetadata, toCamelCase } from '../../scripts/aem.js';
 import { fetchTagList, formatDate, getContentType } from '../../scripts/utils.js';
 import Tag from '../../libs/tag/tag.js';
 import { buildAuthorUrl, getAuthorEntries, getAuthorNames } from '../../scripts/article.js';
@@ -79,11 +77,17 @@ function decorateMetaInfo() {
   return infoBlockWrapper;
 }
 
-function replacePlaceholderText(elem, placeholder) {
+function replacePlaceholderText(elem, tags) {
   if (elem && (elem.innerText.includes('[page]') || elem.innerText.includes('[author]'))) {
-    const adaptedPath = toCamelCase(window.location.pathname
-      .replace('tags', 'tag').replace('topics', 'topic').substring(1));
-    elem.innerHTML = elem.innerHTML.replace('[page]', placeholder[adaptedPath] ? placeholder[adaptedPath] : '');
+    // find the first tag in tags which matches the path in topics-path or news-path
+    let h1TitleTag;
+    Object.keys(tags).forEach((tag) => {
+      const tagData = tags[tag];
+      if (tagData['topic-path'] === window.location.pathname || tagData['news-path'] === window.location.pathname) {
+        h1TitleTag = tagData;
+      }
+    });
+    elem.innerHTML = elem.innerHTML.replace('[page]', h1TitleTag?.label || '');
     elem.innerHTML = elem.innerHTML.replace('[author]', getMetadata('author') || '');
   }
   return elem;
@@ -108,7 +112,6 @@ function findFirstTag() {
 export default async function decorate(block) {
   const isArticle = getMetadata('template') === 'article';
   const isMediaBlend = isArticle || block.classList.contains('media-blend');
-  const placeholder = await fetchPlaceholders();
   const tags = await fetchTagList();
 
   // extract block content
@@ -145,7 +148,7 @@ export default async function decorate(block) {
       class: ['hero-banner', 'media-blend__content'],
     },
     newEyebrow,
-    replacePlaceholderText(heading, placeholder),
+    replacePlaceholderText(heading, tags),
   );
   hero.append(contentSlot);
 


### PR DESCRIPTION
Filter all internal tags which are either not defined in the Content Hub tag list or don't have path assigned.

Relates to #391

Test URLs:
Before: https://main--hlx-test--urfuwo.hlx.live/news/2020/02/sap-proaxia-intelligent-enterprise-solution-automotive-retail-sap-s-4hana
After: https://feat-500-tagfilter--hlx-test--urfuwo.hlx.live/news/2020/02/sap-proaxia-intelligent-enterprise-solution-automotive-retail-sap-s-4hana

