### PR TITLE
501: Fix content-list top spacing in sections with background and column sections

### DIFF
--- a/aemedge/blocks/content-list/content-list.css
+++ b/aemedge/blocks/content-list/content-list.css
@@ -93,9 +93,6 @@ body.hub-l2 .content-list {
   }
 }
 
-.section.background-light,
-.section.background-dark {
-  .content-list:first-child {
-    margin-top: var(--udexSpacer56);
-  }
+:is(.background-light, .background-dark):has(.content-list-wrapper:first-child) {
+  padding-block-start: var(--udexSpacer56);
 }


### PR DESCRIPTION
This is a quick fix specifically for content list as this is causing a spacing issue on the main homepage.
Ideally we need to rework how we apply spacing to the sections and blocks in hub and article pages so that it is more generic and  individual blocks don't have to worry about specifying vertical margin/padding. We can address this on a more after we receive feedback from Elaine, with more explicit rules defined as to how spacing should be applied between elements.

Note: Content list currently a bit broken as tagging changes in progress.

Fix #501

Test URLs:
**Content Hub:**
Before: https://main--hlx-test--urfuwo.hlx.live/topics/
After: https://501-content-list-spacing--hlx-test--urfuwo.hlx.live/topics/
Before: https://main--hlx-test--urfuwo.hlx.live/design/stories-resources/
After: https://501-content-list-spacing--hlx-test--urfuwo.hlx.live/design/stories-resources/