### PR TITLE
chore: filter content-type from article tag list

### DIFF
--- a/aemedge/blocks/article-tags/article-tags.js
+++ b/aemedge/blocks/article-tags/article-tags.js
@@ -12,7 +12,7 @@ export default async function decorate(block) {
     const tags = await fetchTagList();
     const tagsLiEL = articleTags.split(', ').filter((articleTag) => {
       const tag = tags[toCamelCase(articleTag)];
-      return tag && (tag['topic-path'] || tag['news-path']);
+      return tag && !tag.key.startsWith('content-type/') && (tag['topic-path'] || tag['news-path']);
     }).map((articleTag) => {
       const tag = tags[toCamelCase(articleTag)];
       return new Tag(tag).render();


### PR DESCRIPTION
Relates #391 

Test URLs:
Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
After: https://391-taglist--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications

