### PR TITLE
Analytics feedback: Prefix page name with site name and colon

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -409,11 +409,12 @@ async function loadPage() {
 async function initDataLayer() {
   window.adobeDataLayer = [];
   const loginStatus = window.sessionStorage.getItem('loginStatus') === 'logY' ? 'yes' : 'no';
+  const siteName = 'sap';
   window.adobeDataLayer.push({
     event: 'globalDL',
     site: {
       country: 'glo',
-      name: 'sap',
+      name: siteName,
     },
     user: {
       type: 'visitor',
@@ -426,7 +427,7 @@ async function initDataLayer() {
     page: {
       country: 'glo',
       language: 'en',
-      name: window.location.pathname,
+      name: `${siteName}:${window.location.pathname}`,
       section: relpath.indexOf('/') > 0 ? relpath.substring(0, relpath.indexOf('/')) : relpath,
       url: window.location.href,
       referrer: document.referrer,


### PR DESCRIPTION
feedback: analytics page name must be prefixed by site name and colon

Fix #522

Test URLs:
Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/12/being-human-in-the-age-of-ai
After: https://522-analytics-validation-feedback-iteration-1--hlx-test--urfuwo.hlx.live/blog/2023/12/being-human-in-the-age-of-ai

Validation: Append ?tr to the after URL, reload the page. Wait 3s for Launch to run. Execute in console: adobeDataLayer.getState() > inspect DL: page > name . Must be prefixed by sap: (see below)

<img width="341" alt="Screenshot 2024-04-24 at 12 49 19" src="https://github.com/urfuwo/hlx-test/assets/33486726/73355688-75c3-48c0-a467-cfce6ac1fdd1">
