### PR TITLE
#512 feat: added first styles for the web-component template (taken f…

### DIFF
--- a/aemedge/templates/web-component/web-component.css
+++ b/aemedge/templates/web-component/web-component.css
@@ -1,1 +1,97 @@
-/* web component css here */
+/* TODO: WIP */
+html:has(.web-component) {
+  height: 100%;
+}
+
+.web-component.appear {
+  --headerHeight: 60px;
+  
+  grid-template:
+    'content' 1fr
+    'footer' auto
+    / 1fr;
+  height: 100%;
+  padding-top: var(--headerHeight);
+  
+  @media (width >= 980px) {
+    display: grid;
+  }
+  
+  @media (width >= 1600px) {
+    & {
+      --udexGridMargins: 246px;
+    }
+  }
+  
+  /* Master Header */
+  & > header {
+    /* grid-area: header; */
+    background: var(--udexColorGrey1);
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: 20;
+  }
+  
+  /* Main Navigation, not part of the grid */
+  & > nav {
+    z-index: 10;
+  }
+  
+  /* Main Content */
+  & > main {
+    display: flex;
+    flex-direction: column;
+    grid-area: content;
+    
+    /* S */
+    @media (width >= 640px) {
+      & > * {
+        /* --udexGridXLGutters */
+        --hero-margin--left: 48px;
+      }
+    }
+    
+    & > :not(.hero-container, .title-banner-container) {
+      & > * {
+        margin: 0 var(--udexGridMargins);
+      }
+    }
+    
+    /* M */
+    @media (width >= 980px) {
+      margin: 0 0 0 var(--udexGridMargins);
+      
+      & .hero-container + .section {
+        padding-block-start: 84px;
+      }
+      
+      & > :not(.hero-container, .title-banner-container) {
+        /* padding-inline: var(--udexGridMargins); */
+        padding-inline: var(--udexGridGutters) var(--udexGridMargins);
+        
+        & > * {
+          margin: unset;
+        }
+      }
+    }
+    
+    & > :not(:last-child, .hero-container) {
+      padding-block-end: var(--udexSpacer56);
+    }
+    
+    & > :last-child {
+      padding-block-end: var(--udexSpacer84);
+    }
+  }
+  
+  /* Page Footer */
+  & > footer {
+    grid-area: footer;
+    
+    /* M */
+    @media (width >= 980px) {
+      margin: 0 0 0 var(--udexGridXLGutters);
+    }
+  }
+}

--- a/aemedge/templates/web-component/web-component.js
+++ b/aemedge/templates/web-component/web-component.js
@@ -1,5 +1,10 @@
+import { nav } from '../../scripts/dom-builder.js';
+
 function decorate(doc) {
-  console.log('Decorating web component', doc);
+  const main = doc.querySelector('main');
+  const mainNavContainer = nav();
+  main.parentNode.insertBefore(mainNavContainer, main);
+  console.log('Decorating web-component template', doc);
 }
 
 decorate(document);


### PR DESCRIPTION
Additions to #512

- moved designportal CSS #370 to the new created web-component template styles (the footer seems a little bit out of place, this will be fixed later in the main-nav issue, styles are based on the content hub implementation and needs to be adjusted for DS) :work-in-progress:
- :info: all upcoming changes will be done in the blocks
- set up a placeholder for the main-nav (preparation)

# Test URLs

## Design System

- Before: https://main--hlx-test--urfuwo.hlx.live/fiori-design-web/button-web-component
- After: https://basic-web-component--hlx-test--urfuwo.hlx.live/fiori-design-web/button-web-component