### PR TITLE
Revert data layer page name computation logic

### DIFF
--- a/aemedge/scripts/scripts.js
+++ b/aemedge/scripts/scripts.js
@@ -409,12 +409,11 @@ async function loadPage() {
 async function initDataLayer() {
   window.adobeDataLayer = [];
   const loginStatus = window.sessionStorage.getItem('loginStatus') === 'logY' ? 'yes' : 'no';
-  const siteName = 'sap';
   window.adobeDataLayer.push({
     event: 'globalDL',
     site: {
       country: 'glo',
-      name: siteName,
+      name: 'sap',
     },
     user: {
       type: 'visitor',
@@ -427,7 +426,7 @@ async function initDataLayer() {
     page: {
       country: 'glo',
       language: 'en',
-      name: `${siteName}:${window.location.pathname}`,
+      name: window.location.pathname,
       section: relpath.indexOf('/') > 0 ? relpath.substring(0, relpath.indexOf('/')) : relpath,
       url: window.location.href,
       referrer: document.referrer,


### PR DESCRIPTION
In the data layer, do not prefix the page name with site name and colon

Fix #531 

Test URLs:
Before: https://main--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications
After: https://531-analytics-pagename-logic--hlx-test--urfuwo.hlx.live/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications

Validation:
* Add ?tr to the URL to enable Analytics for this (DEV) domain, in browser console: adobeDataLayer.getState() > inspect page > name. Must not have a "sap:" prefix. The path name must only contain the (absolute) path, e.g. "/blog/2023/11/idc-marketscape-sap-a-leader-cloud-enabled-sourcing-applications"