### PR TITLE
chore: implement generic news center "tag" for hero

### DIFF
--- a/aemedge/blocks/hero/hero.js
+++ b/aemedge/blocks/hero/hero.js
@@ -2,7 +2,7 @@ import '@udex/webcomponents/dist/HeroBanner.js';
 import {
   a, div, p, span,
 } from '../../scripts/dom-builder.js';
-import { getMetadata, toCamelCase } from '../../scripts/aem.js';
+import { fetchPlaceholders, getMetadata, toCamelCase } from '../../scripts/aem.js';
 import { fetchTagList, formatDate, getContentType } from '../../scripts/utils.js';
 import Tag from '../../libs/tag/tag.js';
 import { buildAuthorUrl, getAuthorEntries, getAuthorNames } from '../../scripts/article.js';
@@ -182,11 +182,16 @@ export default async function decorate(block) {
     }
   });
 
-  // Add Primary tag
+  // Add primary tag or news placeholder
   const tagContainer = div({ class: 'media-blend__tags' });
-  const firstTag = findFirstTag();
-  if (firstTag) {
-    tagContainer.append(new Tag(tags[toCamelCase(firstTag)]).render());
+  if (window.location.pathname.startsWith('/news/') && isArticle) {
+    const placeholders = await fetchPlaceholders();
+    tagContainer.append(new Tag({ key: 'news-center', label: placeholders[toCamelCase('SAP News Center')], 'news-path': '/news' }).render());
+  } else {
+    const firstTag = findFirstTag();
+    if (firstTag) {
+      tagContainer.append(new Tag(tags[toCamelCase(firstTag)]).render());
+    }
   }
 
   // convert all buttons to udex-buttons

--- a/aemedge/blocks/hero/hero.js
+++ b/aemedge/blocks/hero/hero.js
@@ -106,10 +106,7 @@ function findFirstTag(tags) {
     const tag = tags[toCamelCase(articleTag)];
     return tag && !tag.key.startsWith('content-type/') && (tag['topic-path'] || tag['news-path']);
   }).map((articleTag) => new Tag(tags[toCamelCase(articleTag)]));
-  // get the first tag from the list of tags
   return tagsLiEL[0];
-
-  // return metaTags.find((tag) => !tag.trim().toLowerCase().startsWith('content-type/'));
 }
 
 /**

--- a/aemedge/blocks/hero/hero.js
+++ b/aemedge/blocks/hero/hero.js
@@ -100,9 +100,16 @@ function buildEyebrow(content) {
   );
 }
 
-function findFirstTag() {
-  const tags = getMetadata('article:tag').split(', ');
-  return tags.find((tag) => tag.trim().toLowerCase().startsWith('topic/') || tag.trim().toLowerCase().startsWith('industry/'));
+function findFirstTag(tags) {
+  const articleTags = getMetadata('article:tag');
+  const tagsLiEL = articleTags.split(', ').filter((articleTag) => {
+    const tag = tags[toCamelCase(articleTag)];
+    return tag && !tag.key.startsWith('content-type/') && (tag['topic-path'] || tag['news-path']);
+  }).map((articleTag) => new Tag(tags[toCamelCase(articleTag)]));
+  // get the first tag from the list of tags
+  return tagsLiEL[0];
+
+  // return metaTags.find((tag) => !tag.trim().toLowerCase().startsWith('content-type/'));
 }
 
 /**
@@ -186,11 +193,17 @@ export default async function decorate(block) {
   const tagContainer = div({ class: 'media-blend__tags' });
   if (window.location.pathname.startsWith('/news/') && isArticle) {
     const placeholders = await fetchPlaceholders();
-    tagContainer.append(new Tag({ key: 'news-center', label: placeholders[toCamelCase('SAP News Center')], 'news-path': '/news' }).render());
+    tagContainer.append(
+      new Tag({
+        key: 'news-center',
+        label: placeholders[toCamelCase('SAP News Center')],
+        'news-path': '/news',
+      }).render(),
+    );
   } else {
-    const firstTag = findFirstTag();
+    const firstTag = findFirstTag(tags);
     if (firstTag) {
-      tagContainer.append(new Tag(tags[toCamelCase(firstTag)]).render());
+      tagContainer.append(firstTag.render());
     }
   }
 


### PR DESCRIPTION
Fix #536, #537

Test URLs:

Before: https://main--hlx-test--urfuwo.hlx.live/news/2023/12/ai-powered-startup-partner-solutions-sap-io
After: https://537-news-hero-tag--hlx-test--urfuwo.hlx.live/news/2023/12/ai-powered-startup-partner-solutions-sap-io

Before: https://main--hlx-test--urfuwo.hlx.live/blogs/2023/09/sap-new-zealand-rugby-honor-old-traditions-digitalize-for-the-future
After: https://537-news-hero-tag--hlx-test--urfuwo.hlx.live/blogs/2023/09/sap-new-zealand-rugby-honor-old-traditions-digitalize-for-the-future